### PR TITLE
Makes generate_display_name method protected rather than private.

### DIFF
--- a/python/shotgun_model/shotgunmodel.py
+++ b/python/shotgun_model/shotgunmodel.py
@@ -134,7 +134,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
 
         self.__download_thumbs = download_thumbs
 
-        
+
 
     ########################################################################################
     # public methods
@@ -672,7 +672,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
         # is universal across time zones and DST changes.
         #
         # When you are pulling data from the shotgun model and want to convert this unix timestamp
-        # to a *local* timezone object, which is typically what you want when you are 
+        # to a *local* timezone object, which is typically what you want when you are
         # displaying a value on screen, use the following code:
         # >>> local_datetime = datetime.fromtimestamp(unix_time)
         #
@@ -841,7 +841,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
         on_leaf_level = len(remaining_fields) == 0
 
         # get the item we need at this level. Create it if not found.
-        field_display_name = self.__generate_display_name(field, sg_item)
+        field_display_name = self._generate_display_name(field, sg_item)
         found_item = None
         for row_index in range(root.rowCount()):
             child = root.child(row_index)
@@ -978,7 +978,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
                 filtered_results.append(sg_item)
 
                 # and store it in our unique dictionary
-                field_display_name = self.__generate_display_name(field, sg_item)
+                field_display_name = self._generate_display_name(field, sg_item)
                 # and associate the shotgun data so that we can find it later
 
                 if on_leaf_level and field_display_name in discrete_values:
@@ -1069,7 +1069,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
                 return False
         return True
 
-    def __generate_display_name(self, field, sg_data):
+    def _generate_display_name(self, field, sg_data):
         """
         Generates a name from a shotgun field.
         For non-nested structures, this is typically just "code".


### PR DESCRIPTION
Makes generate_display_name protected rather than private so it can be overridden by a subclass!