### PR TITLE
#26518 #27462 Updates to how data caches are organized on disk

### DIFF
--- a/python/shotgun_model/shotgunmodel.py
+++ b/python/shotgun_model/shotgunmodel.py
@@ -317,8 +317,8 @@ class ShotgunModel(QtGui.QStandardItemModel):
         # params_hash is an md5 hash representing all parameters going into a particular  
         # query setup and filters_hash is an md5 hash of the filter conditions.
         #
-        # the reason these are split up is because the params tend to be constant for a single
-        # applications where the filters keep varying.
+        # the reason these are split up is because the params tend to be constant and
+        # the filters keep varying depending on user input.
 
         # now hash up the rest of the parameters and make that the filename
         params_hash = hashlib.md5()


### PR DESCRIPTION
While this update will work with pre-015 cores (where cache files will be stored in the pipeline configuration cache directory), it is really intended as a 0.15 followup, attempting to resolve some things related to the cache storage:
- sg data caches are now stored in the official bundle cache location, allowing clients to customize the location of cache data. In addition, it also creates a more clear, standardized structure and resolves potential buildup of cache files in temp storage, which sometimes is highly limited by design.
- we have seen potential evidence of md5 cache collisions with the current implementation, where a large number of parameters are squeezed into a single string that is md5 hashed. This change breaks out the structure further and hopefully no collisions should appear.
- improved I/O handling around cache writes.

This is a screenshot of the new structure (on a mac residing in `~/Library/caches`)

![screen shot 2014-12-02 at 13 56 28](https://cloud.githubusercontent.com/assets/337710/5263636/6182e24e-7a2b-11e4-80c5-63a94fb1c43e.png)
