### PR TITLE
#30106 asynchronous loading of thumbnails

### DIFF
--- a/python/shotgun_data/sgdata.py
+++ b/python/shotgun_data/sgdata.py
@@ -719,7 +719,7 @@ class ShotgunDataRetriever(QtCore.QThread):
                         url = sg_data[field]
                         path_to_cached_thumb = self._get_thumbnail_path(url, self._bundle)
                         self._bundle.ensure_folder_exists(os.path.dirname(path_to_cached_thumb))
-                        tank.util.download_url(self._bundle.shotgun, url, path_to_cached_thumb)
+                        tank.util.download_url(self.__sg, url, path_to_cached_thumb)
                         # modify the permissions of the file so it's writeable by others
                         old_umask = os.umask(0)
                         try:

--- a/python/shotgun_data/sgdata.py
+++ b/python/shotgun_data/sgdata.py
@@ -556,7 +556,11 @@ class ShotgunDataRetriever(QtCore.QThread):
             self._queue_mutex.lock()
             try:
 
-                if len(self._sg_requests_queue) > 0:
+                if len(self._thumb_check_queue) > 0:
+                    item_to_process = self._thumb_check_queue.pop(0)
+                    item_type = ShotgunDataRetriever._THUMB_CHECK
+
+                elif len(self._sg_requests_queue) > 0:
                     item_to_process = self._sg_requests_queue.pop(0)
                     if item_to_process["action"] == "execute_find":
                         item_type = ShotgunDataRetriever._SG_FIND_QUERY
@@ -574,11 +578,6 @@ class ShotgunDataRetriever(QtCore.QThread):
 
                     elif item_to_process["action"] == "execute_method":
                         item_type = ShotgunDataRetriever._EXECUTE_METHOD
-
-                elif len(self._thumb_check_queue) > 0:
-                    item_to_process = self._thumb_check_queue.pop(0)
-                    item_type = ShotgunDataRetriever._THUMB_CHECK
-
 
                 elif len(self._thumb_download_queue) > 0:
                     item_to_process = self._thumb_download_queue.pop(0)
@@ -625,8 +624,6 @@ class ShotgunDataRetriever(QtCore.QThread):
             try:
 
                 # process the item:
-                
-                # start with thumbnail I/O checks since they are the fastest to execute
                 if item_type == ShotgunDataRetriever._THUMB_CHECK:
                     # check if a thumbnail exists on disk. If not, fall back onto
                     # a thumbnail download from shotgun/s3

--- a/python/shotgun_model/shotgunmodel.py
+++ b/python/shotgun_model/shotgunmodel.py
@@ -736,6 +736,8 @@ class ShotgunModel(QtGui.QStandardItemModel):
         uid = sanitize_qt(uid) # qstring on pyqt, str on pyside
         data = sanitize_qt(data)
 
+        self.__log_debug("Received worker payload of type %s" % request_type)
+        
         if self.__current_work_id == uid:
             # our publish data has arrived from sg!
 

--- a/python/shotgun_model/shotgunmodel.py
+++ b/python/shotgun_model/shotgunmodel.py
@@ -748,20 +748,23 @@ class ShotgunModel(QtGui.QStandardItemModel):
             thumbnail_path = data["thumb_path"]
             thumbnail = data["image"]
             
+            # if the requested thumbnail has since dissapeared on the server,
+            # path and image will be None. In this case, skip processing
+            if thumbnail_path:
 
-            item = self.__thumb_map[uid]["item"]
-            sg_field = self.__thumb_map[uid]["field"]
-
-            # call our deriving class implementation
-            if self.__bg_thumbs:
-                # worker thread already loaded the thumbnail in as a QImage.
-                # call a separate method.
-                self._populate_thumbnail_image(item, sg_field, thumbnail, thumbnail_path)
-                
-            else:
-                # worker thread only ensured that the image exists
-                # call method to populate it
-                self._populate_thumbnail(item, sg_field, thumbnail_path)
+                item = self.__thumb_map[uid]["item"]
+                sg_field = self.__thumb_map[uid]["field"]
+    
+                # call our deriving class implementation
+                if self.__bg_thumbs:
+                    # worker thread already loaded the thumbnail in as a QImage.
+                    # call a separate method.
+                    self._populate_thumbnail_image(item, sg_field, thumbnail, thumbnail_path)
+                    
+                else:
+                    # worker thread only ensured that the image exists
+                    # call method to populate it
+                    self._populate_thumbnail(item, sg_field, thumbnail_path)
             
 
     def __on_sg_data_arrived(self, sg_data):

--- a/python/shotgun_model/shotgunmodel.py
+++ b/python/shotgun_model/shotgunmodel.py
@@ -90,7 +90,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
     FILE_VERSION = 21
 
 
-    def __init__(self, parent, download_thumbs=True, schema_generation=0):
+    def __init__(self, parent, download_thumbs=True, schema_generation=0, bg_thumbs=False):
         """
         Constructor. This will create a model which can later be used to load
         and manage Shotgun data.
@@ -102,6 +102,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
                                   of the data you are retrieving from Shotgun, and therefore
                                   want to invalidate any cache files that may already exist
                                   in the system, you can increment this integer.
+        :param bg_thumbs: If set to True, thumbnails will be loaded in the background.
 
         """
         QtGui.QStandardItemModel.__init__(self, parent)
@@ -116,6 +117,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
         self.__current_work_id = 0
         self.__schema_generation = schema_generation
         self.__full_cache_path = None
+        
 
         # and start its thread!
         self.__sg_data_retriever.start()
@@ -134,7 +136,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
         self.__thumb_map = {}
 
         self.__download_thumbs = download_thumbs
-
+        self.__bg_thumbs = bg_thumbs
 
     ########################################################################################
     # public methods
@@ -524,7 +526,11 @@ class ShotgunModel(QtGui.QStandardItemModel):
             # nothing to download. bad input. gracefully ignore this request.
             return
 
-        uid = self.__sg_data_retriever.request_thumbnail(url, entity_type, entity_id, field)
+        uid = self.__sg_data_retriever.request_thumbnail(url, 
+                                                         entity_type, 
+                                                         entity_id, 
+                                                         field, 
+                                                         self.__bg_thumbs)
 
         # keep tabs of this and call out later
         self.__thumb_map[uid] = {"item": item, "field": field }
@@ -626,6 +632,25 @@ class ShotgunModel(QtGui.QStandardItemModel):
         thumb = QtGui.QPixmap(path)
         item.setIcon(thumb)
 
+    def _populate_thumbnail_image(self, item, field, image, path):
+        """
+        Similar to _populate_thumbnail() but this method is called instead
+        when the bg_thumbs parameter has been set to true. In this case, no
+        loading of thumbnail data from disk is necessary - this has already been
+        carried out async and is passed in the form of a QImage object.
+    
+        For further details, see _populate_thumbnail()
+        
+        :param item: QStandardItem which is associated with the given thumbnail
+        :param field: The Shotgun field which the thumbnail is associated with.
+        :param image: QImage object with the thumbnail loaded
+        :param path: A path on disk to the thumbnail. This is a file in jpeg format.
+        """
+        # the default implementation sets the icon
+        thumb = QtGui.QPixmap.fromImage(image)
+        item.setIcon(thumb)
+
+    
     def _before_data_processing(self, sg_data_list):
         """
         Called just after data has been retrieved from Shotgun but before any processing
@@ -720,16 +745,27 @@ class ShotgunModel(QtGui.QStandardItemModel):
         elif uid in self.__thumb_map:
             # a thumbnail is now present on disk!
             thumbnail_path = data["thumb_path"]
+            thumbnail = data["image"]
+            
 
             item = self.__thumb_map[uid]["item"]
             sg_field = self.__thumb_map[uid]["field"]
 
             # call our deriving class implementation
-            self._populate_thumbnail(item, sg_field, thumbnail_path)
+            if self.__bg_thumbs:
+                # worker thread already loaded the thumbnail in as a QImage.
+                # call a separate method.
+                self._populate_thumbnail_image(item, sg_field, thumbnail, thumbnail_path)
+                
+            else:
+                # worker thread only ensured that the image exists
+                # call method to populate it
+                self._populate_thumbnail(item, sg_field, thumbnail_path)
+            
 
     def __on_sg_data_arrived(self, sg_data):
         """
-        Handle asynchronous shotgun data arrivin after a find request.
+        Handle asynchronous shotgun data arriving after a find request.
         """
 
         self.__log_debug("--> Shotgun data arrived. (%s records)" % len(sg_data))
@@ -1031,7 +1067,8 @@ class ShotgunModel(QtGui.QStandardItemModel):
                 uid = self.__sg_data_retriever.request_thumbnail(sg_data[field],
                                                                  sg_data.get("type"),
                                                                  sg_data.get("id"),
-                                                                 field)
+                                                                 field,
+                                                                 self.__bg_thumbs)
 
                 self.__thumb_map[uid] = {"item": item, "field": field }
 

--- a/python/shotgun_model/shotgunmodel.py
+++ b/python/shotgun_model/shotgunmodel.py
@@ -720,6 +720,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
 
         if self.__current_work_id != uid:
             # not our job. ignore
+            self.__log_debug("Retrieved error from data worker: %s" % msg)
             return
 
         full_msg = "Error retrieving data from Shotgun: %s" % msg

--- a/python/shotgun_model/shotgunmodel.py
+++ b/python/shotgun_model/shotgunmodel.py
@@ -90,7 +90,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
     FILE_VERSION = 21
 
 
-    def __init__(self, parent, download_thumbs=True, schema_generation=0, bg_thumbs=False):
+    def __init__(self, parent, download_thumbs=True, schema_generation=0, bg_load_thumbs=False):
         """
         Constructor. This will create a model which can later be used to load
         and manage Shotgun data.
@@ -102,7 +102,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
                                   of the data you are retrieving from Shotgun, and therefore
                                   want to invalidate any cache files that may already exist
                                   in the system, you can increment this integer.
-        :param bg_thumbs: If set to True, thumbnails will be loaded in the background.
+        :param bg_load_thumbs: If set to True, thumbnails will be loaded in the background.
 
         """
         QtGui.QStandardItemModel.__init__(self, parent)
@@ -136,7 +136,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
         self.__thumb_map = {}
 
         self.__download_thumbs = download_thumbs
-        self.__bg_thumbs = bg_thumbs
+        self.__bg_load_thumbs = bg_load_thumbs
 
     ########################################################################################
     # public methods
@@ -530,7 +530,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
                                                          entity_type, 
                                                          entity_id, 
                                                          field, 
-                                                         self.__bg_thumbs)
+                                                         self.__bg_load_thumbs)
 
         # keep tabs of this and call out later
         self.__thumb_map[uid] = {"item": item, "field": field }
@@ -635,7 +635,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
     def _populate_thumbnail_image(self, item, field, image, path):
         """
         Similar to _populate_thumbnail() but this method is called instead
-        when the bg_thumbs parameter has been set to true. In this case, no
+        when the bg_load_thumbs parameter has been set to true. In this case, no
         loading of thumbnail data from disk is necessary - this has already been
         carried out async and is passed in the form of a QImage object.
     
@@ -758,7 +758,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
                 sg_field = self.__thumb_map[uid]["field"]
     
                 # call our deriving class implementation
-                if self.__bg_thumbs:
+                if self.__bg_load_thumbs:
                     # worker thread already loaded the thumbnail in as a QImage.
                     # call a separate method.
                     self._populate_thumbnail_image(item, sg_field, thumbnail, thumbnail_path)
@@ -1090,7 +1090,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
                                                                  sg_data.get("type"),
                                                                  sg_data.get("id"),
                                                                  field,
-                                                                 self.__bg_thumbs)
+                                                                 self.__bg_load_thumbs)
 
                 self.__thumb_map[uid] = {"item": item, "field": field }
 

--- a/python/shotgun_model/shotgunoverlaymodel.py
+++ b/python/shotgun_model/shotgunoverlaymodel.py
@@ -33,7 +33,7 @@ class ShotgunOverlayModel(ShotgunModel):
     # should be deactivated. 
     progress_spinner_end = QtCore.Signal()
 
-    def __init__(self, parent, overlay_widget, download_thumbs=True, schema_generation=0):
+    def __init__(self, parent, overlay_widget, download_thumbs=True, schema_generation=0, bg_thumbs=False):
         """
         Constructor. This will create a model which can later be used to load
         and manage Shotgun data.
@@ -46,9 +46,10 @@ class ShotgunOverlayModel(ShotgunModel):
                                   of the data you are retrieving from Shotgun, and therefore
                                   want to invalidate any cache files that may already exist
                                   in the system, you can increment this integer.
+        :param bg_thumbs: If set to True, thumbnails will be loaded in the background.
         
         """
-        ShotgunModel.__init__(self, parent, download_thumbs, schema_generation)
+        ShotgunModel.__init__(self, parent, download_thumbs, schema_generation, bg_thumbs)
         
         # set up our spinner UI handling
         self.__overlay = overlay_module.ShotgunOverlayWidget(overlay_widget)

--- a/python/shotgun_model/shotgunoverlaymodel.py
+++ b/python/shotgun_model/shotgunoverlaymodel.py
@@ -33,7 +33,7 @@ class ShotgunOverlayModel(ShotgunModel):
     # should be deactivated. 
     progress_spinner_end = QtCore.Signal()
 
-    def __init__(self, parent, overlay_widget, download_thumbs=True, schema_generation=0, bg_thumbs=False):
+    def __init__(self, parent, overlay_widget, download_thumbs=True, schema_generation=0, bg_load_thumbs=False):
         """
         Constructor. This will create a model which can later be used to load
         and manage Shotgun data.
@@ -46,10 +46,10 @@ class ShotgunOverlayModel(ShotgunModel):
                                   of the data you are retrieving from Shotgun, and therefore
                                   want to invalidate any cache files that may already exist
                                   in the system, you can increment this integer.
-        :param bg_thumbs: If set to True, thumbnails will be loaded in the background.
+        :param bg_load_thumbs: If set to True, thumbnails will be loaded in the background.
         
         """
-        ShotgunModel.__init__(self, parent, download_thumbs, schema_generation, bg_thumbs)
+        ShotgunModel.__init__(self, parent, download_thumbs, schema_generation, bg_load_thumbs)
         
         # set up our spinner UI handling
         self.__overlay = overlay_module.ShotgunOverlayWidget(overlay_widget)


### PR DESCRIPTION
Fully backwards compatible. Adds a new `bg_thumbs` flag to the ShotgunModel family;

```
def __init__(self, parent, download_thumbs=True, schema_generation=0, bg_thumbs=False):
         """
         Constructor. This will create a model which can later be used to load
         and manage Shotgun data.
 
         :param parent: Parent object.
         :param download_thumbs: Boolean to indicate if this model should attempt
                                 to download and process thumbnails for the downloaded data.
         :param schema_generation: Schema generation index. If you are changing the format
                                   of the data you are retrieving from Shotgun, and therefore
                                   want to invalidate any cache files that may already exist
                                   in the system, you can increment this integer.
        :param bg_thumbs: If set to True, thumbnails will be loaded in the background.
 
         """
```

Setting the flag to True will request that the sgdata async fetcher not only downloads the thumbnail but also loads it up into a `QImage` object. This means that most I/O will happen in the worker thread rather than in the main UI thread. It seems to lead to much better behaviour, especially when you have lots of images.

When `bg_thumbs` is set to `True`, the method `_populate_thumbnail_image()` is called from the base class instead of the normal `_populate_thumbnail()` method. Code subclassing the Shotgun model needs to implement this `_populate_thumbnail_image()` method if they want to take advantage of the new behaviour.

Here's a comparative test on a slow cache storage - showing the new and the old cache running side by side: https://s3.amazonaws.com/uploads.hipchat.com/21107/193181/u7AisV1yqUxMuxx/ScreenFlow.mov

This also improves some other areas:

- Thumbnails are downloaded faster from S3. Instead of doing a find prior to every S3 download, this is only done on failure.
- Thumbs queued up several times (not an uncommon situation) are only dowloaded once.
- Improved debugging.
- Fixed issue with S3 logic inside attachment entities, causing queries pulling down attachment fields with uploads to always invalidate and refresh
- Fixed an issue with callbacks firing when thumbnails are removed on the server and not returned
- Shotgun connections are now created JIT - for optimal performance of initial thumbnail download tasks

Also please note https://github.com/shotgunsoftware/tk-core/commit/14d6bd5e0ec9d663de7486daf11ea7ee6e14e460 - which memoizes cache location. This was slowing down the caching beause it was being called several times. The default hook calls `self.parent.shotgun.base_url`, causing the sg API to initialize inside each worker thread, causing further slowdowns. 