### PR TITLE
Adds support for capped queries

### DIFF
--- a/python/shotgun_model/shotgunmodel.py
+++ b/python/shotgun_model/shotgunmodel.py
@@ -336,7 +336,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
     ########################################################################################
     # protected methods not meant to be subclassed but meant to be called by subclasses
 
-    def _load_data(self, entity_type, filters, hierarchy, fields, order=None, seed=None):
+    def _load_data(self, entity_type, filters, hierarchy, fields, order=None, seed=None, limit=None):
         """
         This is the main method to use to configure the model. You basically
         pass a specific find query to the model and it will start tracking
@@ -382,6 +382,10 @@ class ShotgunModel(QtGui.QStandardItemModel):
                           shotgun query parameters. It may also depend on some external factors. In this case,
                           the cache seed should also be influenced by those parameters and you can pass
                           an external string via this parameter which will be added to the seed.
+        :param limit:     Limit the number of results returned from Shotgun. In conjunction with the order
+                          parameter, this can be used to effectively cap the data set that the model
+                          is handling, allowing a user to for example show the twenty most recent notes or
+                          similar.
 
         :returns:         True if cached data was loaded, False if not.
         """
@@ -397,6 +401,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
         self.__fields = fields
         self.__order = order or []
         self.__hierarchy = hierarchy
+        self.__limit = limit or 0 # 0 means get all matches
 
         # when we cache the data associated with this model, create
         # the file name and path based on several parameters.
@@ -496,7 +501,8 @@ class ShotgunModel(QtGui.QStandardItemModel):
             self.__current_work_id = self.__sg_data_retriever.execute_find(self.__entity_type,
                                                                            self.__filters,
                                                                            fields,
-                                                                           self.__order)
+                                                                           self.__order,
+                                                                           limit=self.__limit)
 
 
     def _request_thumbnail_download(self, item, field, url, entity_type, entity_id):

--- a/python/shotgun_model/shotgunoverlaymodel.py
+++ b/python/shotgun_model/shotgunoverlaymodel.py
@@ -63,14 +63,21 @@ class ShotgunOverlayModel(ShotgunModel):
     ########################################################################################
     # protected methods not meant to be subclassed but meant to be called by subclasses
     
-    def _load_data(self, entity_type, filters, hierarchy, fields, order=None, seed=None):
+    def _load_data(self, entity_type, filters, hierarchy, fields, order=None, seed=None, limit=None):
         """
         Overridden from ShotgunModel. 
         """
         # reset overlay
         self.__overlay.hide(hide_errors=True)
         # call base class
-        self._cache_loaded = ShotgunModel._load_data(self, entity_type, filters, hierarchy, fields, order, seed)
+        self._cache_loaded = ShotgunModel._load_data(self, 
+                                                     entity_type, 
+                                                     filters, 
+                                                     hierarchy, 
+                                                     fields, 
+                                                     order, 
+                                                     seed,
+                                                     limit)
         return self._cache_loaded        
     
     def _refresh_data(self):


### PR DESCRIPTION
You can now define a model which holds a maximum of X entries by passing a limit parameter to the data load command. This is the passed to the Shotgun API find() call to limit the results.