### PR TITLE
For #32981, rebuild slowness in workfiles

### DIFF
--- a/python/shotgun_model/shotgun_model.py
+++ b/python/shotgun_model/shotgun_model.py
@@ -1237,9 +1237,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
                         "children": {}
                     }
 
-                # We're moving down the subtree.
-                if not on_leaf_level:
-                    sub_tree = sub_tree["children"][field_display_name]
+                sub_tree = sub_tree["children"][field_display_name]
 
         self._insert_in_order(tree)
 
@@ -1370,6 +1368,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
         fh = QtCore.QFile(filename)
 
         fh.open(QtCore.QIODevice.ReadOnly)
+
         try:
             in_stream = QtCore.QDataStream(fh)
 


### PR DESCRIPTION
- The model now advertises that it is going to be reset, so any listeners can ignore batch updates or empty their caches. This speeds up tremendously how the tree can be cleared when observers are listening to the model since they can temporarily disconnect from the model to avoid a notifications storm or clear caches of QPersistentModelIndex like the Hierarchical. This goes hand in and with this other [pull request](https://github.com/shotgunsoftware/tk-framework-qtwidgets/pull/8).

- Rewrote how we build the hierarchy from a breadth-first to a depth-first approach.

Here are the performance gain we've had
5000 tasks
8.59 vs 3.53 => 2.43x speed gain
10000 tasks
16.84 vs 6.91 => 2.43x speed gain
15000 tasks
60.71 vs 9.88 => 6.14x speed gain
20000 tasks
90.22 vs 13.18 => 6.84x speed gain
25000 tasks
164.13 vs 20.07 => 8.18x speed gain

What is also great to see is that the time it takes to process more nodes is pretty much linear compared to the old approach which didn't scale nicely.

