### PR TITLE
Ticket #34756 - Adds column support to ShotgunModel

### DIFF
--- a/python/shotgun_model/shotgun_model.py
+++ b/python/shotgun_model/shotgun_model.py
@@ -1498,9 +1498,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
         # the first item in the row is always the standard shotgun model item,
         # but subclasses may provide additional columns to be appended.
         row = [item]
-        additional_columns = self._get_additional_columns(item, is_leaf, self.__column_fields)
-        if additional_columns:
-            row += additional_columns
+        row.extend(self._get_additional_columns(item, is_leaf, self.__column_fields))
         return row
 
     ########################################################################################

--- a/python/shotgun_model/simple_shotgun_model.py
+++ b/python/shotgun_model/simple_shotgun_model.py
@@ -42,22 +42,22 @@ class SimpleShotgunModel(ShotgunModel):
             bg_load_thumbs=True, 
             bg_task_manager=bg_task_manager)
 
-    def load_data(self, entity_type, filters=None, fields=None):
+    def load_data(self, entity_type, filters=None, fields=None, columns=None):
         """
         Loads shotgun data into the model, using the cache if possible.
         The model is not nested and the first field that is specified
         via the fields parameter (``code`` by default) will be used as the default
-        name for all model items. 
-        
+        name for all model items.
+
         :param entity_type: Shotgun Entity Type to load data for
         :param filters: Shotgun API find-style filter list. If no list is specified, all records
                         for the given entity type will be retrieved.
         :param fields: List of Shotgun fields to retrieve. If not spefified, the 'code' field
                        will be retrieved.
+        :param columns: List of Shotgun fields to use to populate the model columns
         """
         filters = filters or []
         fields = fields or ["code"]
         hierarchy = [fields[0]]
-        ShotgunModel._load_data(self, entity_type, filters, hierarchy, fields)
+        ShotgunModel._load_data(self, entity_type, filters, hierarchy, fields, columns=columns)
         self._refresh_data()
-        

--- a/python/shotgun_model/simple_shotgun_model.py
+++ b/python/shotgun_model/simple_shotgun_model.py
@@ -42,7 +42,7 @@ class SimpleShotgunModel(ShotgunModel):
             bg_load_thumbs=True, 
             bg_task_manager=bg_task_manager)
 
-    def load_data(self, entity_type, filters=None, fields=None, columns=None):
+    def load_data(self, entity_type, filters=None, fields=None, order=None, limit=None, columns=None):
         """
         Loads shotgun data into the model, using the cache if possible.
         The model is not nested and the first field that is specified
@@ -51,13 +51,26 @@ class SimpleShotgunModel(ShotgunModel):
 
         :param entity_type: Shotgun Entity Type to load data for
         :param filters: Shotgun API find-style filter list. If no list is specified, all records
-                        for the given entity type will be retrieved.
+                  for the given entity type will be retrieved.
         :param fields: List of Shotgun fields to retrieve. If not spefified, the 'code' field
-                       will be retrieved.
+                  will be retrieved.
+        :param order: Order clause for the Shotgun data. Standard Shotgun API syntax.
+                  Note that this is an advanced parameter which is meant to be used
+                  in subclassing only. The model itself will be ordered by its
+                  default display name, and if any other type of ordering is desirable,
+                  use for example a QProxyModel to handle this. However, knowing in which
+                  order results will arrive from Shotgun can be beneficial if you are doing
+                  grouping, deferred loading and aggregation of data as part of your
+                  subclassed implementation.
+        :param limit: Limit the number of results returned from Shotgun. In conjunction with the order
+                  parameter, this can be used to effectively cap the data set that the model
+                  is handling, allowing a user to for example show the twenty most recent notes or
+                  similar.
         :param columns: List of Shotgun fields to use to populate the model columns
         """
         filters = filters or []
         fields = fields or ["code"]
         hierarchy = [fields[0]]
-        ShotgunModel._load_data(self, entity_type, filters, hierarchy, fields, columns=columns)
+        ShotgunModel._load_data(
+            self, entity_type, filters, hierarchy, fields, order=order, limit=limit, columns=columns)
         self._refresh_data()


### PR DESCRIPTION
Extends ShotgunModel and SimpleShotgunModel so that specific fields from the Shotgun query can be used to populate columns in the model.

To use this functionality, simply pass in an array of fields to the _load_data's new optional columns param.