### PR TITLE
For #35801, file save freeze fix

### DIFF
--- a/python/shotgun_model/shotgun_model.py
+++ b/python/shotgun_model/shotgun_model.py
@@ -248,7 +248,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
               ['sg_status', 'is', 'ip']
             ]
 
-        :param item: One of the :class:`~PySide.QtGui.QStandardItem`s that are
+        :param item: One of the :class:`~PySide.QtGui.QStandardItem` s that are
                      associated with this model.
         :returns: standard shotgun filter list to represent that item
         """
@@ -1493,7 +1493,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
         :param item: A :class:`~PySide.QtGui.QStandardItem` that is associated with this model.
         :param is_leaf: A boolean indicating if the item is a leaf item or not
 
-        :returns: A list of :class:`~PySide.QtGui.QStandardItem`s
+        :returns: A list of :class:`~PySide.QtGui.QStandardItem` s
         """
         # the first item in the row is always the standard shotgun model item,
         # but subclasses may provide additional columns to be appended.

--- a/python/task_manager/background_task_manager.py
+++ b/python/task_manager/background_task_manager.py
@@ -1,14 +1,16 @@
 # Copyright (c) 2015 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import traceback
+"""
+Background task manager.
+"""
 
 import sgtk
 from sgtk.platform.qt import QtCore
@@ -17,26 +19,29 @@ from sgtk import TankError
 from .background_task import BackgroundTask
 from .worker_thread import WorkerThread
 
+import Queue
+
+
 class BackgroundTaskManager(QtCore.QObject):
     """
     Main task manager class. Manages a queue of tasks running them asynchronously through
     a pool of worker threads.
 
-    Note that the BackgroundTaskManager class itself is reentrant but not thread-safe so its methods should only 
+    Note that the BackgroundTaskManager class itself is reentrant but not thread-safe so its methods should only
     be called from the thread it is created in. Typically this would be the main thread of the application.
-    
-    
+
+
     :signal task_completed(uid, group, result): Emitted when a task has been completed.
-        The ``uid`` parameter holds the unique id associated with the task, 
-        the ``group`` is the group that the task is associated with and 
-        the ``result`` is the data returned by the task. 
-    
+        The ``uid`` parameter holds the unique id associated with the task,
+        the ``group`` is the group that the task is associated with and
+        the ``result`` is the data returned by the task.
+
     :signal task_failed(uid, group, message, traceback_str): Emitted when a task fails for some reason.
-        The ``uid`` parameter holds the unique id associated with the task, 
-        the ``group`` is the group that the task is associated with, 
+        The ``uid`` parameter holds the unique id associated with the task,
+        the ``group`` is the group that the task is associated with,
         the ``message`` is a short error message and the ``traceback_str``
         holds a full traceback.
-        
+
     :signal task_group_finished(group): Emitted when all tasks in a group have finished.
         The ``group`` is the group that has completed.
 
@@ -83,6 +88,46 @@ class BackgroundTaskManager(QtCore.QObject):
         self._upstream_task_map = {}
         self._downstream_task_map = {}
 
+        # Queue for events being emitted from the background threads.
+        self._bg_thread_task_events = Queue.Queue()
+
+        # Create a timer with no interval. This means the timer will be invoked
+        # only when the event queue is empty.
+        self._timer = QtCore.QTimer()
+        # This should be instantiated from the application's thread since we only support
+        # one instance for now.
+        assert(QtCore.QCoreApplication.instance().thread() == self._timer.thread())
+        # Since the event will be invoked as soon as the event queue is empty,
+        # we should process the queue one item at a time to not interfere with the
+        # ui responsivenes
+        self._timer.timeout.connect(self._execute_one_event)
+        self._timer.start()
+
+    def queue_task_completed(self, worker_thread, task, result):
+        """
+        Called by background threads to notify that a task has completed.
+        """
+        self._bg_thread_task_events.put(
+            lambda: self._on_worker_thread_task_completed(worker_thread, task, result)
+        )
+
+    def queue_task_failed(self, worker_thread, task, msg, callstack):
+        """
+        Called by background threads to notify that a task has failed.
+        """
+        self._bg_thread_task_events.put(
+            lambda: self._on_worker_thread_task_failed(worker_thread, task, msg, callstack)
+        )
+
+    def _execute_one_event(self):
+        try:
+            cb = self._bg_thread_task_events.get_nowait()
+        except Queue.Empty:
+            # Queue is empty, nothing to do!
+            pass
+        else:
+            cb()
+
     def next_group_id(self):
         """
         Return the next available group id
@@ -121,6 +166,8 @@ class BackgroundTaskManager(QtCore.QObject):
         Shut down the task manager.  This clears the task queue and gracefully stops all running
         threads.  Completion/failure of any currently running tasks will be ignored.
         """
+        self._timer.stop()
+
         self._log("Shutting down...")
         self._can_process_tasks = False
 
@@ -148,9 +195,9 @@ class BackgroundTaskManager(QtCore.QObject):
         :param upstream_task_ids:   A list of any upstream tasks that should be completed before this task
                                     is run.  The results from any upstream tasks are appended to the kwargs
                                     for this task.
-        :param task_args:           A list of unnamed parameters to be passed to the callable when running the 
+        :param task_args:           A list of unnamed parameters to be passed to the callable when running the
                                     task
-        :param task_kwargs:         A dictionary of named parameters to be passed to the callable when running 
+        :param task_kwargs:         A dictionary of named parameters to be passed to the callable when running
                                     the task
         :returns:                   A unique id representing the task.
         """
@@ -201,7 +248,7 @@ class BackgroundTaskManager(QtCore.QObject):
         :returns:                   A unique id representing the task.
 
         """
-        return self.add_task(self._task_pass_through, priority, group, upstream_task_ids, task_kwargs = task_kwargs)
+        return self.add_task(self._task_pass_through, priority, group, upstream_task_ids, task_kwargs=task_kwargs)
 
     def stop_task(self, task_id, stop_upstream=True, stop_downstream=True):
         """
@@ -222,7 +269,7 @@ class BackgroundTaskManager(QtCore.QObject):
 
     def stop_task_group(self, group, stop_upstream=True, stop_downstream=True):
         """
-        Stop all tasks in the specified group from running.  If any tasks are already running then they will 
+        Stop all tasks in the specified group from running.  If any tasks are already running then they will
         complete but their completion/failure signals will be ignored.
 
         :param group:           The task group to stop
@@ -247,7 +294,7 @@ class BackgroundTaskManager(QtCore.QObject):
 
     def stop_all_tasks(self):
         """
-        Stop all currently queued or running tasks.  If any tasks are already running then they will 
+        Stop all currently queued or running tasks.  If any tasks are already running then they will
         complete but their completion/failure signals will be ignored.
         """
         self._log("Stopping all tasks...")
@@ -307,7 +354,7 @@ class BackgroundTaskManager(QtCore.QObject):
 
     def _get_worker_thread(self):
         """
-        Get a worker thread to use.  
+        Get a worker thread to use.
 
         :returns:   An available worker thread if there is one, a new thread if needed or None if the thread
                     limit has been reached.
@@ -332,8 +379,8 @@ class BackgroundTaskManager(QtCore.QObject):
             # will at least continue correctly and not do unexpected things!
             self._bundle.log_error("Failed to create background worker thread for task Manager!")
             return None
-        thread.task_failed.connect(self._on_worker_thread_task_failed)
-        thread.task_completed.connect(self._on_worker_thread_task_completed)
+#        thread.task_failed.connect(self._on_worker_thread_task_failed)
+#        thread.task_completed.connect(self._on_worker_thread_task_completed)
         self._all_threads.append(thread)
 
         # start the thread - this will just put it into wait mode:
@@ -355,7 +402,7 @@ class BackgroundTaskManager(QtCore.QObject):
 
     def _start_next_task(self):
         """
-        Start the next task in the queue if there is a task that is startable and there is an 
+        Start the next task in the queue if there is a task that is startable and there is an
         available thread to run it.
 
         :returns:    True if a task was started, otherwise False
@@ -417,9 +464,9 @@ class BackgroundTaskManager(QtCore.QObject):
 
         return True
 
-    def _on_worker_thread_task_completed(self, task, result):
+    def _on_worker_thread_task_completed(self, worker_thread, task, result):
         """
-        Slot triggered when a task is completed by a worker thread.  This processes the result and emits the 
+        Slot triggered when a task is completed by a worker thread.  This processes the result and emits the
         task_completed signal if needed.
 
         The worker thread instance that completed the task can be retrieved from self.sender()
@@ -427,8 +474,6 @@ class BackgroundTaskManager(QtCore.QObject):
         :param task:    The task that completed
         :param result:  The task result
         """
-        worker_thread = self.sender()
-
         try:
             # check that we should process this result:
             if task.uid in self._running_tasks:
@@ -459,9 +504,9 @@ class BackgroundTaskManager(QtCore.QObject):
         # start processing of the next task:
         self._start_tasks()
 
-    def _on_worker_thread_task_failed(self, task, msg, tb):
+    def _on_worker_thread_task_failed(self, worker_thread, task, msg, tb):
         """
-        Slot triggered when a task being executed in by a worker thread has failed for some reason.  This processes 
+        Slot triggered when a task being executed in by a worker thread has failed for some reason.  This processes
         the task and emits the task_failed signal if needed.
 
         The worker thread instance that the task failed in can be retrieved from self.sender()
@@ -470,8 +515,6 @@ class BackgroundTaskManager(QtCore.QObject):
         :param msg:     The error message for the failed task
         :param tb:      The stack-trace for the failed task
         """
-        worker_thread = self.sender()
-
         try:
             # check that we should process this task:
             if task.uid in self._running_tasks:
@@ -527,14 +570,14 @@ class BackgroundTaskManager(QtCore.QObject):
             for p_task in self._pending_tasks_by_priority.get(task.priority, []):
                 if p_task.uid == task.uid:
                     self._pending_tasks_by_priority[task.priority].remove(p_task)
-                    break 
+                    break
 
             if not self._pending_tasks_by_priority[task.priority]:
                 del self._pending_tasks_by_priority[task.priority]
 
         # remove this task from all other maps:
-        if (task.group in self._group_task_map 
-            and task.uid in self._group_task_map[task.group]):
+        if (task.group in self._group_task_map and
+                task.uid in self._group_task_map[task.group]):
             self._group_task_map[task.group].remove(task.uid)
             if not self._group_task_map[task.group]:
                 group_completed = True

--- a/python/task_manager/background_task_manager.py
+++ b/python/task_manager/background_task_manager.py
@@ -526,8 +526,9 @@ class BackgroundTaskManager(QtCore.QObject):
 
         The worker thread instance that completed the task can be retrieved from self.sender()
 
-        :param task:    The task that completed
-        :param result:  The task result
+        :param worker_thread: Thread that completed the task.
+        :param task:          The task that completed
+        :param result:        The task result
         """
         try:
             # check that we should process this result:
@@ -566,9 +567,10 @@ class BackgroundTaskManager(QtCore.QObject):
 
         The worker thread instance that the task failed in can be retrieved from self.sender()
 
-        :param task:    The task that failed
-        :param msg:     The error message for the failed task
-        :param tb:      The stack-trace for the failed task
+        :param worker_thread: Thread that completed the task.
+        :param task:          The task that failed
+        :param msg:           The error message for the failed task
+        :param tb:            The stack-trace for the failed task
         """
         try:
             # check that we should process this task:

--- a/python/task_manager/results_poller.py
+++ b/python/task_manager/results_poller.py
@@ -20,23 +20,6 @@ import sgtk
 class ResultsPoller(QtCore.QObject):
     """
     Polls a queue which holds the results posted from the worker threads.
-
-    Signalling between two different threads in PySide is broken in several versions
-    of PySide. There are very subtle race conditions that arise when there is a lot
-    of signalling between two threads. Some of these things have been fixed in later
-    versions of PySide, but most hosts integrate PySide 1.2.2 and lower, which are
-    victim of this race condition.
-
-    The background task manager is a heavy user of signals between two threads and
-    was sometimes causing deadlocks in many Toolkit applications between PySide's
-    SignalManager and the GIL that would essential freeze the host application.
-
-    Therefore, this we use this polling system. The worker threads inserts results
-    inside a queue and the main thread will flush the queue at regular intervals.
-
-    Note that because this queue is polled every 100 milliseconds, it means that
-    there will always we at most a latency of ~100 milliseconds (depending on
-    the OS's timer resolution) between two tasks.
     """
 
     # Emitted when a task is completed.

--- a/python/task_manager/results_poller.py
+++ b/python/task_manager/results_poller.py
@@ -57,7 +57,7 @@ class ResultsPoller(QtCore.QObject):
         self._results = Queue.Queue()
         # Create a timer with no interval. This means the timer will be invoked
         # only when the event queue is empty.
-        self._timer = QtCore.QTimer()
+        self._timer = QtCore.QTimer(parent=self)
         self._timer.setInterval(self._POLLING_INTERVAL)
         # Since the event will be invoked as soon as the event queue is empty,
         # we should process the queue one item at a time to not interfere with the

--- a/python/task_manager/worker_thread.py
+++ b/python/task_manager/worker_thread.py
@@ -27,7 +27,7 @@ class WorkerThread(QtCore.QThread):
         """
         Construction
 
-        :param trp: Results poller from the background task manager.
+        :param rp: Results poller from the background task manager.
         :param parent:  The parent QObject for this thread
         """
         QtCore.QThread.__init__(self, parent)
@@ -36,8 +36,7 @@ class WorkerThread(QtCore.QThread):
         self._process_tasks = True
         self._mutex = QtCore.QMutex()
         self._wait_condition = QtCore.QWaitCondition()
-
-        self._result_poller = rp
+        self._results_poller = rp
 
     def run_task(self, task):
         """
@@ -56,7 +55,7 @@ class WorkerThread(QtCore.QThread):
         """
         Shut down the thread and wait for it to exit before returning
         """
-        self._result_poller = None
+        self._results_poller = None
         self._mutex.lock()
         try:
             self._process_tasks = False
@@ -96,7 +95,7 @@ class WorkerThread(QtCore.QThread):
                     if not self._process_tasks:
                         break
                     # emit the result (non-blocking):
-                    self._result_poller.queue_task_completed(self, task_to_process, result)
+                    self._results_poller.queue_task_completed(self, task_to_process, result)
                 finally:
                     self._mutex.unlock()
             except Exception, e:
@@ -107,7 +106,7 @@ class WorkerThread(QtCore.QThread):
                         break
                     tb = traceback.format_exc()
                     # emit failed signal (non-blocking):
-                    self._result_poller.queue_task_failed(self, task_to_process, str(e), tb)
+                    self._results_poller.queue_task_failed(self, task_to_process, str(e), tb)
                 finally:
                     self._mutex.unlock()
 

--- a/python/task_manager/worker_thread.py
+++ b/python/task_manager/worker_thread.py
@@ -23,11 +23,11 @@ class WorkerThread(QtCore.QThread):
     implements a custom run method that loops over tasks until asked to quit.
     """
 
-    def __init__(self, rp, parent=None):
+    def __init__(self, results_poller, parent=None):
         """
         Construction
 
-        :param rp: Results poller from the background task manager.
+        :param results_poller: Results poller from the background task manager.
         :param parent:  The parent QObject for this thread
         """
         QtCore.QThread.__init__(self, parent)
@@ -36,7 +36,7 @@ class WorkerThread(QtCore.QThread):
         self._process_tasks = True
         self._mutex = QtCore.QMutex()
         self._wait_condition = QtCore.QWaitCondition()
-        self._results_poller = rp
+        self._results_poller = results_poller
 
     def run_task(self, task):
         """


### PR DESCRIPTION
Signalling between two different threads in PySide is broken in several versions of PySide. There are very subtle race conditions that arise when there is a lot of signalling  between two threads. Some of these things have been fixed in later versions of PySide, but most hosts integrate PySide 1.2.2 and lower, which are victim of this race condition.

The background task manager is a heavy user of signals between two threads and was sometimes causing deadlocks in many Toolkit applications between PySide's SignalManager and the GIL that would essential freeze the host application.

Therefore, this branch swaps the background task manager's usage of slots and signals for a polling system. The threads inserts results inside a queue and the main thread will flush the queue at regular intervals.