### PR TITLE
For #35801, file save freeze fix

### DIFF
--- a/python/task_manager/results_poller.py
+++ b/python/task_manager/results_poller.py
@@ -9,7 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
-Results queue poller
+Results dispatcher for the background task manager.
 """
 
 import Queue
@@ -17,17 +17,87 @@ from sgtk.platform.qt import QtCore
 import sgtk
 
 
-class ResultsPoller(QtCore.QObject):
+class TaskCompletedEvent(object):
     """
-    Polls a queue which holds the results posted from the worker threads.
+    Event sent when a task is succesfully completed.
     """
+
+    def __init__(self, worker_thread, task, result, results_queue):
+        """
+        Constructor.
+
+        :param worker_thread: Worker thread that completed sucessfully.
+        :param task: Task id of the completed task.
+        :param result: Result published by the task.
+        :param results_queue: Results queue to signal task completion.
+        """
+        self._worker_thread = worker_thread
+        self._task = task
+        self._result = result
+        self._results_queue = results_queue
+
+    def execute(self):
+        """
+        Signals the task_completed event on the results queue.
+        """
+        self._results_queue.task_completed.emit(self._worker_thread, self._task, self._result)
+
+
+class TaskFailedEvent(object):
+    """
+    Event sent when a task is succesfully completed.
+    """
+
+    def __init__(self, worker_thread, task, msg, traceback_, results_queue):
+        """
+        Constructor.
+
+        :param worker_thread: Worker thread that completed sucessfully.
+        :param task: Task id of the completed task.
+        :param msg: Error message from the worker thread.
+        :param traceback_: Traceback from  the worker thread error.
+        :param results_queue: Results queue to signal task failure.
+        """
+        self._worker_thread = worker_thread
+        self._task = task
+        self._msg = msg
+        self._traceback = traceback_
+        self._results_queue = results_queue
+
+    def execute(self):
+        """
+        Signals the task_failed event on the results queue.
+        """
+        self._results_queue.task_failed.emit(self._worker_thread, self._task, self._msg, self._traceback)
+
+
+class ResultsDispatcher(QtCore.QThread):
+    """
+    Dispatches events synchronously to the thread that owns this object.
+
+    Signalling between two different threads in PySide is broken in several versions
+    of PySide. There are very subtle race conditions that arise when there is a lot
+    of signalling between two threads. Some of these things have been fixed in later
+    versions of PySide, but most hosts integrate PySide 1.2.2 and lower, which are
+    victim of this race condition.
+
+    The background task manager does a lot on inter-threads communications and
+    therefore can easily fall pray to these deadlocks that exist within PySide.
+
+    Therefore, we instead use Qt's QMetaObject invokeMethod to carry information
+    to the background task manager thread in a thread-safe manner, since it
+    doesn't exhibit the bad behaviour from PySide's signals.
+    """
+
+    class _ShutdownHint(object):
+        """
+        Hint to dispatcher that it should shut down.
+        """
 
     # Emitted when a task is completed.
     task_completed = QtCore.Signal(object, object, object)
     # Emitted when a task has failed.
     task_failed = QtCore.Signal(object, object, object, object)
-
-    _POLLING_INTERVAL = 100
 
     def __init__(self, parent=None):
         """
@@ -35,77 +105,83 @@ class ResultsPoller(QtCore.QObject):
 
         :param parent:  The parent QObject for this thread
         """
-        QtCore.QObject.__init__(self, parent)
-        # Results queue that will be polled
+        QtCore.QThread.__init__(self, parent)
+        # Results that will need to be dispatched to the background task
+        # manager.
         self._results = Queue.Queue()
-        # Create a timer with no interval. This means the timer will be invoked
-        # only when the event queue is empty.
-        self._timer = QtCore.QTimer(parent=self)
-        self._timer.setInterval(self._POLLING_INTERVAL)
-        # Since the event will be invoked as soon as the event queue is empty,
-        # we should process the queue one item at a time to not interfere with the
-        # ui responsivenes
-        self._timer.timeout.connect(self._flush_events)
         self._bundle = sgtk.platform.current_bundle()
 
-    def start(self):
+    def _log(self, msg):
         """
-        Start polling for tasks that ended.
+        Logs a message at the debug level.
         """
-        self._timer.start()
+        self._bundle.log_debug("Results Queue: %s" % msg)
 
     def shut_down(self):
         """
-        Stop polling for tasks that ended.
+        Shuts down the result dispatcher thread.
         """
-        self._timer.stop()
+        # Add an event in the queue that will tell the thread to terminate.
+        self._results.put(self._ShutdownHint())
+        self._log("Sent _ShutdownHint to consumer thread.")
+        # Do not wait for the thread here!!! The backgroud thread is invoking
+        # the main thread synchronously. Waiting here would introduce
+        # a deadlock because the main thread would be waiting for the dispatcher
+        # to end and the dispatcher would be waiting for his events to
+        # be processed by the main thread.
 
-    def _flush_events(self):
+    def run(self):
         """
         Executes callbacks for each task result.
         """
+        while True:
+            # Wait for the next result
+            self._event = self._results.get(block=True)
+            # If we're told that we need to quit, do it.
+            if isinstance(self._event, self._ShutdownHint):
+                self._log("Consumer thread received ShutdownHint.")
+                break
+
+            # In order to keep this loop simple, we will assume that the background
+            # task manager is always opened for business. The manager already ignores
+            # out of bounds events so no need to complicate the code here as well.
+
+            # A thread's object self.thread() is actually the thread that created
+            # the thread object. In this case, self's thread affinity is the
+            # same as the background task manager. Therefore, using QMetaObject
+            # to invoke a method in the thread of self means invoking it
+            # in the thread of the background manager as well. self._fn will
+            # therefore be executed in the correct thread.
+
+            # A note on thread safety. We could have used a QueuedConnection here
+            # in order to implement a fire and forget scheme, which would be ideal.
+            # However, this wouldn't bring a lot of advantages. Since the only communication
+            # channel between the dispatcher and the backgroud manager is the self._fn
+            # variable, it means that the access to that variable must be made thread-safe
+            # so that it is not updated before the event is executed in the main thread.
+            # Doing so would require adding locks and complicate the code further.
+            # Using the builtin lock from the invoker here is much easier to understand.
+
+            # We could also add the events to invoke into a second queue meant to
+            # be consumed by the background task manager, but it would only add
+            # complexity to the design and it wouldn't provide any significant speed gain.
+            QtCore.QMetaObject.invokeMethod(self, "_do_invoke", QtCore.Qt.BlockingQueuedConnection)
+
+    @QtCore.Slot()
+    def _do_invoke(self):
+        """
+        Executes the event to dispatch.
+        """
         try:
-            # Get everything until the queue is empty.
-            while True:
-                # Get the next result from the queue
-                result_tuple = self._results.get_nowait()
-                try:
-                    # Result tuples with 3 values are coming from succesful tasks.
-                    if len(result_tuple) == 3:
-                        self.task_completed.emit(*result_tuple)
-                    else:
-                        # Result tuples with 4 values are coming from succesful tasks.
-                        self.task_failed.emit(*result_tuple)
-                except Exception:
-                    self._bundle.log_exception(
-                        "Exception thrown while reporting completed task."
-                    )
-                    # Do not re-raise, simply process the remaining events.
-        except Queue.Empty:
-            # Queue is empty, nothing to do!
-            pass
+            self._event.execute()
+            self._event
+        except Exception:
+            self._bundle.log_exception("Exception thrown while reporting ended task.")
 
-    def queue_task_completed(self, worker_thread, task, result):
+    def produce_event(self, event):
         """
-        Called by background threads to notify that a task has completed.
+        Called by background threads to notify that a task has ended.
 
-        :param worker_thread: Thread that completed the task.
-        :param task: Task that was completed.
-        :param result: Result produced by the thread.
+        :param event: Event to notify
         """
-        self._results.put(
-            (worker_thread, task, result)
-        )
-
-    def queue_task_failed(self, worker_thread, task, msg, traceback_):
-        """
-        Called by background threads to notify that a task has failed.
-
-        :param worker_thread: Thread that completed the task.
-        :param task: Task that failed.
-        :param msg: Error message from the task,
-        :param traceback_: Call stack from the task.
-        """
-        self._results.put(
-            (worker_thread, task, msg, traceback_)
-        )
+        self._results.put(event)

--- a/python/task_manager/worker_thread.py
+++ b/python/task_manager/worker_thread.py
@@ -13,10 +13,7 @@ Worker thread for the background manager.
 """
 
 import traceback
-
 from sgtk.platform.qt import QtCore
-
-from .results_poller import TaskCompletedEvent, TaskFailedEvent
 
 
 class WorkerThread(QtCore.QThread):
@@ -97,11 +94,10 @@ class WorkerThread(QtCore.QThread):
                     if not self._process_tasks:
                         break
                     # emit the result (non-blocking):
-                    self._results_dispatcher.produce_event(TaskCompletedEvent(self, task_to_process, result, self._results_dispatcher))
+                    self._results_dispatcher.emit_completed(self, task_to_process, result)
                 finally:
                     self._mutex.unlock()
             except Exception, e:
-                print e
                 # something went wrong so emit failed signal:
                 self._mutex.lock()
                 try:
@@ -109,111 +105,6 @@ class WorkerThread(QtCore.QThread):
                         break
                     tb = traceback.format_exc()
                     # emit failed signal (non-blocking):
-                    self._results_dispatcher.produce_event(TaskFailedEvent(self, task_to_process, str(e), tb, self._results_dispatcher))
+                    self._results_dispatcher.emit_failure(self, task_to_process, str(e), tb)
                 finally:
                     self._mutex.unlock()
-
-
-# class WorkerThreadSeparateThread(QtCore.QThread):
-#     """
-#     Asynchronous worker thread that can run tasks in a separate thread.  This implementation
-#     uses a separate worker object that exists in the new thread and then uses signals to
-#     communicate back and forth.
-#
-#     Note, this recipe exhibits odd behaviour in PyQt.  When initially created, the instance returned
-#     in the assignment isn't always of type WorkerThreadB!, e.g.:
-#
-#         thread = WorkerThreadB()
-#         assert isinstance(thread, WorkerThreadB) # this should never assert!
-#
-#     Although this recipe is recommended in Qt as it is arguably a more 'correct' use of QThreads, it
-#     is currently advised that the the overridden run recipe (WorkerThreadA) be used instead whilst
-#     Toolkit needs to support PyQt.
-#     """
-#     class _Worker(QtCore.QObject):
-#         """
-#         Thread worker that just does work when requested.
-#         """
-#         # Signal emitted when a task has completed successfully
-#         task_completed = QtCore.Signal(object, object)# task, result
-#         # Signal emitted when a task has failed
-#         task_failed = QtCore.Signal(object, object, object)# task, message, stacktrace
-#
-#         def __init__(self):
-#             """
-#             Construction
-#             """
-#             QtCore.QObject.__init__(self, None)
-#
-#         def do_task(self, task):
-#             """
-#             Run a single task.
-#             """
-#             try:
-#                 # run the task:
-#                 result = task.run()
-#                 # emit result:
-#                 self.task_completed.emit(task, result)
-#             except Exception, e:
-#                 # something went wrong so emit failed signal:
-#                 tb = traceback.format_exc()
-#                 self.task_failed.emit(task, str(e), tb)
-#
-#     # Signal used to tell the worker that a task should be run
-#     work = QtCore.Signal(object)# task
-#     # Signal emitted when a task has completed successfully
-#     task_completed = QtCore.Signal(object, object)# task, result
-#     # Signal emitted when a task has failed
-#     task_failed = QtCore.Signal(object, object, object)# task, message, stacktrace
-#
-#     def __init__(self, parent=None):
-#         """
-#         Construction
-#
-#         :param parent:  The parent QObject for this thread
-#         """
-#         QtCore.QThread.__init__(self, parent)
-#
-#         # create the worker instance:
-#         self._worker = WorkerThreadB._Worker()
-#
-#         # move the worker to the thread and then connect up the signals
-#         # that are used to communicate with it:
-#         self._worker.moveToThread(self)
-#         self.work.connect(self._worker.do_task)
-#         self._worker.task_failed.connect(self.task_failed)
-#         self._worker.task_completed.connect(self.task_completed)
-#
-#     def run_task(self, task):
-#         """
-#         Run the specified task
-#
-#         :param task:    The task to run
-#         """
-#         # signal the worker to run the task
-#         self.work.emit(task)
-#
-#     def shut_down(self):
-#         """
-#         Shut down the thread and wait for it to exit before returning
-#         """
-#         self.quit()
-#         self.wait()
-#         # the worker has now been moved back into the main thread so lets
-#         # parent it to this thread so that it gets safely cleaned up
-#         self._worker.setParent(self)
-#         self._worker = None
-#
-#     def run(self):
-#         """
-#         Normally we wouldn't need to override the run method as by default it just runs the event
-#         loop for the thread but due to a but in Qt pre-4.8 we have to do some extra stuff to make
-#         sure everything gets cleaned up properly!
-#         """
-#         # run the event loop:
-#         self.exec_()
-#
-#         # before we quit, we need to move the worker back to the main thread.  This is to work around
-#         # issues with Qt pre-4.8 where any QObject.deleteLater's aren't executed on thread exit
-#         # which would result in the worker not being cleaned up correctly!
-#         self._worker.moveToThread(QtCore.QCoreApplication.instance().thread())


### PR DESCRIPTION
The polling was replaced by a consumer thread that dispatches the events to the background manager's thread using QMetaObject.invokeMethod, which has shown to be reliable in the past and not introduce deadlocks between PySide and the GIL.