### PR TITLE
Adds support for additional_filter_presets to the ShotgunModel.

### DIFF
--- a/python/shotgun_globals/__init__.py
+++ b/python/shotgun_globals/__init__.py
@@ -24,3 +24,4 @@ get_data_type = _cs.CachedShotgunSchema.get_data_type
 get_status_display_name = _cs.CachedShotgunSchema.get_status_display_name
 get_status_color = _cs.CachedShotgunSchema.get_status_color
 get_valid_types = _cs.CachedShotgunSchema.get_valid_types
+get_ordered_status_list = _cs.CachedShotgunSchema.get_ordered_status_list

--- a/python/shotgun_globals/cached_schema.py
+++ b/python/shotgun_globals/cached_schema.py
@@ -429,6 +429,13 @@ class CachedShotgunSchema(QtCore.QObject):
         :returns: Data type string
         """
         self = cls.__get_instance()
+
+        # Detect bubble fields. If the field_name is "sg_sequence.Sequence.code"
+        # then we know we want to get the data type of the "code" field on the
+        # "Sequence" entity type.
+        if "." in field_name:
+            (sg_entity_type, field_name) = field_name.split(".")[-2:]
+
         self._check_schema_refresh(sg_entity_type, field_name)
 
         if sg_entity_type in self._type_schema and field_name in self._field_schema[sg_entity_type]:

--- a/python/shotgun_model/shotgun_model.py
+++ b/python/shotgun_model/shotgun_model.py
@@ -441,7 +441,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
                                           that the data from the loaded entity will be available field by field. Subclasses can modify
                                           this behavior by overriding _get_additional_columns.
         :param additional_filter_presets: List of Shotgun filter presets to apply, e.g.
-                                          [{"preset_name":"LATEST","latest_by":"BY_PIPELINE_STEP_NUMBER_AND_ENTITIES_CREATED_AT"}]
+                                          ``[{"preset_name":"LATEST","latest_by":"BY_PIPELINE_STEP_NUMBER_AND_ENTITIES_CREATED_AT"}]``
 
         :returns:                         True if cached data was loaded, False if not.
         """
@@ -459,7 +459,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
         self.__hierarchy = hierarchy
         self.__column_fields = columns or []
         self.__limit = limit or 0 # 0 means get all matches
-        self.__additional_filter_presets = additional_filter_presets or []
+        self.__additional_filter_presets = additional_filter_presets
 
         # when we cache the data associated with this model, create
         # the file name and path based on several parameters.

--- a/python/shotgun_model/shotgun_model.py
+++ b/python/shotgun_model/shotgun_model.py
@@ -441,7 +441,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
                                           that the data from the loaded entity will be available field by field. Subclasses can modify
                                           this behavior by overriding _get_additional_columns.
         :param additional_filter_presets: List of Shotgun filter presets to apply, e.g.
-                                          [{"preset_name": "LATEST", "latest_by": "BY_PIPELINE_STEP_NUMBER_AND_ENTITIES_CREATED_AT" }]
+                                          [{"preset_name":"LATEST","latest_by":"BY_PIPELINE_STEP_NUMBER_AND_ENTITIES_CREATED_AT"}]
 
         :returns:                         True if cached data was loaded, False if not.
         """
@@ -499,13 +499,13 @@ class ShotgunModel(QtGui.QStandardItemModel):
         params_hash.update(str(self.__fields))
         params_hash.update(str(self.__order))
         params_hash.update(str(self.__hierarchy))
-        params_hash.update(str(self.__additional_filter_presets))
 
         # now hash up the filter parameters and the seed - these are dynamic
         # values that tend to change and be data driven, so they are handled
         # on a different level in the path
         filter_hash = hashlib.md5()
         filter_hash.update(str(self.__filters))
+        filter_hash.update(str(self.__additional_filter_presets))
         params_hash.update(str(seed))
 
         # organize files on disk based on entity type and then filter hash

--- a/python/shotgun_model/shotgun_model.py
+++ b/python/shotgun_model/shotgun_model.py
@@ -382,7 +382,10 @@ class ShotgunModel(QtGui.QStandardItemModel):
     ########################################################################################
     # protected methods not meant to be subclassed but meant to be called by subclasses
 
-    def _load_data(self, entity_type, filters, hierarchy, fields, order=None, seed=None, limit=None, columns=None):
+    def _load_data(
+        self, entity_type, filters, hierarchy, fields, order=None, seed=None, limit=None,
+        columns=None, additional_filter_presets=None
+    ):
         """
         This is the main method to use to configure the model. You basically
         pass a specific find query to the model and it will start tracking
@@ -397,47 +400,50 @@ class ShotgunModel(QtGui.QStandardItemModel):
         If you want to refresh the data contained in the model (which you typically
         want to), call the :meth:`_refresh_data()` method.
 
-        :param entity_type: Shotgun entity type to download
-        :param filters:   List of Shotgun filters. Standard Shotgun syntax. Passing None instead of a list of
-                          filters indicates that no shotgun data should be retrieved and no API calls will be made.
-        :param hierarchy: List of grouping fields. These should be names of Shotgun
-                          fields. If you for example want to create a list of items,
-                          the value ``["code"]`` will be suitable. This will generate a data
-                          model which is flat and where each item's default name is the
-                          Shotgun name field. If you want to generate a tree where assets
-                          are broken down by asset type, you could instead specify
-                          ``["sg_asset_type", "code"]``.
-        :param fields:    Fields to retrieve from Shotgun (in addition to the ones specified
-                          in the hierarchy parameter). Standard Shotgun API syntax. If you
-                          specify None for this parameter, Shotgun will not be called when
-                          the _refresh_data() method is being executed.
-        :param order:     Order clause for the Shotgun data. Standard Shotgun API syntax.
-                          Note that this is an advanced parameter which is meant to be used
-                          in subclassing only. The model itself will be ordered by its
-                          default display name, and if any other type of ordering is desirable,
-                          use for example a QProxyModel to handle this. However, knowing in which
-                          order results will arrive from Shotgun can be beneficial if you are doing
-                          grouping, deferred loading and aggregation of data as part of your
-                          subclassed implementation, typically via the :meth:`_before_data_processing()` method.
-        :param seed:      Advanced parameter. With each shotgun query being cached on disk, the model
-                          generates a cache seed which it is using to store data on disk. Since the cache
-                          data on disk is a reflection of a particular shotgun query, this seed is typically
-                          generated from the various query and field parameters passed to this method. However,
-                          in some cases when you are doing advanced subclassing, for example when you are culling
-                          out data based on some external state, the model state does not solely depend on the
-                          shotgun query parameters. It may also depend on some external factors. In this case,
-                          the cache seed should also be influenced by those parameters and you can pass
-                          an external string via this parameter which will be added to the seed.
-        :param limit:     Limit the number of results returned from Shotgun. In conjunction with the order
-                          parameter, this can be used to effectively cap the data set that the model
-                          is handling, allowing a user to for example show the twenty most recent notes or
-                          similar.
-        :param columns:   If columns is specified, then any leaf row in the model will have columns created where
-                          each column in the row contains the value for the corresponding field from columns. This means
-                          that the data from the loaded entity will be available field by field. Subclasses can modify
-                          this behavior by overriding _get_additional_columns.
+        :param entity_type:               Shotgun entity type to download
+        :param filters:                   List of Shotgun filters. Standard Shotgun syntax. Passing None instead
+                                          of a list of filters indicates that no shotgun data should be retrieved
+                                          and no API calls will be made.
+        :param hierarchy:                 List of grouping fields. These should be names of Shotgun
+                                          fields. If you for example want to create a list of items,
+                                          the value ``["code"]`` will be suitable. This will generate a data
+                                          model which is flat and where each item's default name is the
+                                          Shotgun name field. If you want to generate a tree where assets
+                                          are broken down by asset type, you could instead specify
+                                          ``["sg_asset_type", "code"]``.
+        :param fields:                    Fields to retrieve from Shotgun (in addition to the ones specified
+                                          in the hierarchy parameter). Standard Shotgun API syntax. If you
+                                          specify None for this parameter, Shotgun will not be called when
+                                          the _refresh_data() method is being executed.
+        :param order:                     Order clause for the Shotgun data. Standard Shotgun API syntax.
+                                          Note that this is an advanced parameter which is meant to be used
+                                          in subclassing only. The model itself will be ordered by its
+                                          default display name, and if any other type of ordering is desirable,
+                                          use for example a QProxyModel to handle this. However, knowing in which
+                                          order results will arrive from Shotgun can be beneficial if you are doing
+                                          grouping, deferred loading and aggregation of data as part of your
+                                          subclassed implementation, typically via the :meth:`_before_data_processing()` method.
+        :param seed:                      Advanced parameter. With each shotgun query being cached on disk, the model
+                                          generates a cache seed which it is using to store data on disk. Since the cache
+                                          data on disk is a reflection of a particular shotgun query, this seed is typically
+                                          generated from the various query and field parameters passed to this method. However,
+                                          in some cases when you are doing advanced subclassing, for example when you are culling
+                                          out data based on some external state, the model state does not solely depend on the
+                                          shotgun query parameters. It may also depend on some external factors. In this case,
+                                          the cache seed should also be influenced by those parameters and you can pass
+                                          an external string via this parameter which will be added to the seed.
+        :param limit:                     Limit the number of results returned from Shotgun. In conjunction with the order
+                                          parameter, this can be used to effectively cap the data set that the model
+                                          is handling, allowing a user to for example show the twenty most recent notes or
+                                          similar.
+        :param columns:                   If columns is specified, then any leaf row in the model will have columns created where
+                                          each column in the row contains the value for the corresponding field from columns. This means
+                                          that the data from the loaded entity will be available field by field. Subclasses can modify
+                                          this behavior by overriding _get_additional_columns.
+        :param additional_filter_presets: List of Shotgun filter presets to apply, e.g.
+                                          [{"preset_name": "LATEST", "latest_by": "BY_PIPELINE_STEP_NUMBER_AND_ENTITIES_CREATED_AT" }]
 
-        :returns:         True if cached data was loaded, False if not.
+        :returns:                         True if cached data was loaded, False if not.
         """
         # we are changing the query
         self.query_changed.emit()
@@ -453,6 +459,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
         self.__hierarchy = hierarchy
         self.__column_fields = columns or []
         self.__limit = limit or 0 # 0 means get all matches
+        self.__additional_filter_presets = additional_filter_presets or []
 
         # when we cache the data associated with this model, create
         # the file name and path based on several parameters.
@@ -492,6 +499,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
         params_hash.update(str(self.__fields))
         params_hash.update(str(self.__order))
         params_hash.update(str(self.__hierarchy))
+        params_hash.update(str(self.__additional_filter_presets))
 
         # now hash up the filter parameters and the seed - these are dynamic
         # values that tend to change and be data driven, so they are handled
@@ -521,6 +529,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
         self.__log_debug("Fields: %s" % self.__fields)
         self.__log_debug("Order: %s" % self.__order)
         self.__log_debug("Columns: %s" % self.__column_fields)
+        self.__log_debug("Filter Presets: %s" % self.__additional_filter_presets)
 
         self.__log_debug("First population pass: Calling _load_external_data()")
         self._load_external_data()
@@ -542,8 +551,10 @@ class ShotgunModel(QtGui.QStandardItemModel):
                                 "full SG load. Error reported: %s" % e)
 
         # set our headers
-        headers = [self.FIRST_COLUMN_HEADER] + \
-            self._get_additional_column_headers(self.__entity_type, self.__column_fields)
+        headers = [self.FIRST_COLUMN_HEADER] + self._get_additional_column_headers(
+            self.__entity_type,
+            self.__column_fields,
+        )
         self.setHorizontalHeaderLabels(headers)
 
         return loaded_cache_data
@@ -598,11 +609,14 @@ class ShotgunModel(QtGui.QStandardItemModel):
                 fields = fields + ["image"]
             fields = list(set(fields))
 
-            self.__current_work_id = self.__sg_data_retriever.execute_find(self.__entity_type,
-                                                                           self.__filters,
-                                                                           fields,
-                                                                           self.__order,
-                                                                           limit=self.__limit)
+            self.__current_work_id = self.__sg_data_retriever.execute_find(
+                self.__entity_type,
+                self.__filters,
+                fields,
+                self.__order,
+                limit=self.__limit,
+                additional_filter_presets=self.__additional_filter_presets,
+            )
 
 
     def _request_thumbnail_download(self, item, field, url, entity_type, entity_id):

--- a/python/shotgun_model/simple_shotgun_model.py
+++ b/python/shotgun_model/simple_shotgun_model.py
@@ -71,7 +71,7 @@ class SimpleShotgunModel(ShotgunModel):
                   similar.
         :param columns: List of Shotgun fields to use to populate the model columns
         :param additional_filter_presets: List of Shotgun filter presets to apply, e.g.
-                  [{"preset_name": "LATEST", "latest_by": "BY_PIPELINE_STEP_NUMBER_AND_ENTITIES_CREATED_AT" }]
+                  [{"preset_name":"LATEST","latest_by":"BY_PIPELINE_STEP_NUMBER_AND_ENTITIES_CREATED_AT"}]
         """
         filters = filters or []
         fields = fields or ["code"]

--- a/python/shotgun_model/simple_shotgun_model.py
+++ b/python/shotgun_model/simple_shotgun_model.py
@@ -42,7 +42,10 @@ class SimpleShotgunModel(ShotgunModel):
             bg_load_thumbs=True, 
             bg_task_manager=bg_task_manager)
 
-    def load_data(self, entity_type, filters=None, fields=None, order=None, limit=None, columns=None):
+    def load_data(
+        self, entity_type, filters=None, fields=None, order=None, limit=None,
+        columns=None, additional_filter_presets=None
+    ):
         """
         Loads shotgun data into the model, using the cache if possible.
         The model is not nested and the first field that is specified
@@ -67,10 +70,21 @@ class SimpleShotgunModel(ShotgunModel):
                   is handling, allowing a user to for example show the twenty most recent notes or
                   similar.
         :param columns: List of Shotgun fields to use to populate the model columns
+        :param additional_filter_presets: List of Shotgun filter presets to apply, e.g.
+                  [{"preset_name": "LATEST", "latest_by": "BY_PIPELINE_STEP_NUMBER_AND_ENTITIES_CREATED_AT" }]
         """
         filters = filters or []
         fields = fields or ["code"]
         hierarchy = [fields[0]]
         ShotgunModel._load_data(
-            self, entity_type, filters, hierarchy, fields, order=order, limit=limit, columns=columns)
+            self,
+            entity_type,
+            filters,
+            hierarchy,
+            fields,
+            order=order,
+            limit=limit,
+            columns=columns,
+            additional_filter_presets=additional_filter_presets,
+        )
         self._refresh_data()

--- a/python/shotgun_model/simple_shotgun_model.py
+++ b/python/shotgun_model/simple_shotgun_model.py
@@ -71,7 +71,7 @@ class SimpleShotgunModel(ShotgunModel):
                   similar.
         :param columns: List of Shotgun fields to use to populate the model columns
         :param additional_filter_presets: List of Shotgun filter presets to apply, e.g.
-                  [{"preset_name":"LATEST","latest_by":"BY_PIPELINE_STEP_NUMBER_AND_ENTITIES_CREATED_AT"}]
+                  ``[{"preset_name":"LATEST","latest_by":"BY_PIPELINE_STEP_NUMBER_AND_ENTITIES_CREATED_AT"}]``
         """
         filters = filters or []
         fields = fields or ["code"]


### PR DESCRIPTION
ShotgunModel and SimpleShotgunModel now accept an optional additional_filter_presets argument that is passed down to any API find calls that are run under the hood. If used, it is also incorporated into the caching mechanism's hashing routine.