### PR TITLE
Adds support for additional_filter_presets to the ShotgunModel.

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -22,7 +22,7 @@ description: "A Collection of QT objects and utilities to simplify app developme
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-requires_core_version: "v0.18.0"
+requires_core_version: "v0.14.58"
 
 # the frameworks required to run this app
 frameworks:

--- a/info.yml
+++ b/info.yml
@@ -22,7 +22,7 @@ description: "A Collection of QT objects and utilities to simplify app developme
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-requires_core_version: "v0.14.58"
+requires_core_version: "v0.18.0"
 
 # the frameworks required to run this app
 frameworks:

--- a/python/shotgun_globals/__init__.py
+++ b/python/shotgun_globals/__init__.py
@@ -12,6 +12,7 @@
 from . import cached_schema as _cs
 
 from .icon import get_entity_type_icon, get_entity_type_icon_url
+from .date_time import create_human_readable_timestamp
 
 register_bg_task_manager = _cs.CachedShotgunSchema.register_bg_task_manager
 unregister_bg_task_manager = _cs.CachedShotgunSchema.unregister_bg_task_manager

--- a/python/shotgun_globals/date_time.py
+++ b/python/shotgun_globals/date_time.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2016 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import datetime
+
+def create_human_readable_timestamp(dt, postfix=""):
+    """
+    Return the time represented by the argument as a string where the date portion is
+    displayed as "Yesterday", "Today", or "Tomorrow" if appropriate.
+
+    By default just the date is displayed, but additional formatting can be appended
+    by using the postfix argument.
+
+    :param dt: The date and time to convert to a string
+    :type dt: :class:`datetime.datetime` or float
+
+    :param postfix: What will be displayed after the date portion of the dt argument
+    :type postfix: A strftime style String
+
+    :returns: A String representing dt appropriate for display
+    """
+    # shotgun_model converts datetimes to floats representing unix time so
+    # handle that as a valid value as well
+    if isinstance(dt, float):
+        dt = datetime.datetime.fromtimestamp(dt)
+
+    # get the delta and components
+    delta = datetime.datetime.now(dt.tzinfo) - dt
+
+    if delta.days == 1:
+        format = "Yesterday%s" % postfix
+    elif delta.days == 0:
+        format = "Today%s" % postfix
+    elif delta.days == -1:
+        format = "Tomorrow%s" % postfix
+    else:
+        # use the date formatting associated with the current locale
+        format = "%%x%s" % postfix
+
+    time_str = dt.strftime(format)
+    return time_str
+

--- a/python/shotgun_model/shotgun_model.py
+++ b/python/shotgun_model/shotgun_model.py
@@ -441,7 +441,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
                                           that the data from the loaded entity will be available field by field. Subclasses can modify
                                           this behavior by overriding _get_additional_columns.
         :param additional_filter_presets: List of Shotgun filter presets to apply, e.g.
-                                          [{"preset_name":"LATEST","latest_by":"BY_PIPELINE_STEP_NUMBER_AND_ENTITIES_CREATED_AT"}]
+                                          ``[{"preset_name":"LATEST","latest_by":"BY_PIPELINE_STEP_NUMBER_AND_ENTITIES_CREATED_AT"}]``
 
         :returns:                         True if cached data was loaded, False if not.
         """
@@ -459,7 +459,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
         self.__hierarchy = hierarchy
         self.__column_fields = columns or []
         self.__limit = limit or 0 # 0 means get all matches
-        self.__additional_filter_presets = additional_filter_presets or []
+        self.__additional_filter_presets = additional_filter_presets
 
         # when we cache the data associated with this model, create
         # the file name and path based on several parameters.

--- a/python/shotgun_model/shotgun_model.py
+++ b/python/shotgun_model/shotgun_model.py
@@ -609,13 +609,22 @@ class ShotgunModel(QtGui.QStandardItemModel):
                 fields = fields + ["image"]
             fields = list(set(fields))
 
+            find_kwargs = dict(
+                limit=self.__limit,
+            )
+
+            # We only want to include the filter presets kwarg if it was explicitly asked
+            # for. The reason for this is that it's a Shotgun 7.0 feature server side, and
+            # we don't want to break backwards compatibility with older versions of Shotgun.
+            if self__additional_filter_presets:
+                find_kwargs["additional_filter_presets"] = self.__additional_filter_presets
+
             self.__current_work_id = self.__sg_data_retriever.execute_find(
                 self.__entity_type,
                 self.__filters,
                 fields,
                 self.__order,
-                limit=self.__limit,
-                additional_filter_presets=self.__additional_filter_presets,
+                **find_kwargs
             )
 
 

--- a/python/shotgun_model/shotgun_model.py
+++ b/python/shotgun_model/shotgun_model.py
@@ -441,7 +441,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
                                           that the data from the loaded entity will be available field by field. Subclasses can modify
                                           this behavior by overriding _get_additional_columns.
         :param additional_filter_presets: List of Shotgun filter presets to apply, e.g.
-                                          [{"preset_name": "LATEST", "latest_by": "BY_PIPELINE_STEP_NUMBER_AND_ENTITIES_CREATED_AT" }]
+                                          [{"preset_name":"LATEST","latest_by":"BY_PIPELINE_STEP_NUMBER_AND_ENTITIES_CREATED_AT"}]
 
         :returns:                         True if cached data was loaded, False if not.
         """
@@ -499,13 +499,13 @@ class ShotgunModel(QtGui.QStandardItemModel):
         params_hash.update(str(self.__fields))
         params_hash.update(str(self.__order))
         params_hash.update(str(self.__hierarchy))
-        params_hash.update(str(self.__additional_filter_presets))
 
         # now hash up the filter parameters and the seed - these are dynamic
         # values that tend to change and be data driven, so they are handled
         # on a different level in the path
         filter_hash = hashlib.md5()
         filter_hash.update(str(self.__filters))
+        filter_hash.update(str(self.__additional_filter_presets))
         params_hash.update(str(seed))
 
         # organize files on disk based on entity type and then filter hash

--- a/python/shotgun_model/shotgun_model.py
+++ b/python/shotgun_model/shotgun_model.py
@@ -382,7 +382,10 @@ class ShotgunModel(QtGui.QStandardItemModel):
     ########################################################################################
     # protected methods not meant to be subclassed but meant to be called by subclasses
 
-    def _load_data(self, entity_type, filters, hierarchy, fields, order=None, seed=None, limit=None, columns=None):
+    def _load_data(
+        self, entity_type, filters, hierarchy, fields, order=None, seed=None, limit=None,
+        columns=None, additional_filter_presets=None
+    ):
         """
         This is the main method to use to configure the model. You basically
         pass a specific find query to the model and it will start tracking
@@ -397,47 +400,50 @@ class ShotgunModel(QtGui.QStandardItemModel):
         If you want to refresh the data contained in the model (which you typically
         want to), call the :meth:`_refresh_data()` method.
 
-        :param entity_type: Shotgun entity type to download
-        :param filters:   List of Shotgun filters. Standard Shotgun syntax. Passing None instead of a list of
-                          filters indicates that no shotgun data should be retrieved and no API calls will be made.
-        :param hierarchy: List of grouping fields. These should be names of Shotgun
-                          fields. If you for example want to create a list of items,
-                          the value ``["code"]`` will be suitable. This will generate a data
-                          model which is flat and where each item's default name is the
-                          Shotgun name field. If you want to generate a tree where assets
-                          are broken down by asset type, you could instead specify
-                          ``["sg_asset_type", "code"]``.
-        :param fields:    Fields to retrieve from Shotgun (in addition to the ones specified
-                          in the hierarchy parameter). Standard Shotgun API syntax. If you
-                          specify None for this parameter, Shotgun will not be called when
-                          the _refresh_data() method is being executed.
-        :param order:     Order clause for the Shotgun data. Standard Shotgun API syntax.
-                          Note that this is an advanced parameter which is meant to be used
-                          in subclassing only. The model itself will be ordered by its
-                          default display name, and if any other type of ordering is desirable,
-                          use for example a QProxyModel to handle this. However, knowing in which
-                          order results will arrive from Shotgun can be beneficial if you are doing
-                          grouping, deferred loading and aggregation of data as part of your
-                          subclassed implementation, typically via the :meth:`_before_data_processing()` method.
-        :param seed:      Advanced parameter. With each shotgun query being cached on disk, the model
-                          generates a cache seed which it is using to store data on disk. Since the cache
-                          data on disk is a reflection of a particular shotgun query, this seed is typically
-                          generated from the various query and field parameters passed to this method. However,
-                          in some cases when you are doing advanced subclassing, for example when you are culling
-                          out data based on some external state, the model state does not solely depend on the
-                          shotgun query parameters. It may also depend on some external factors. In this case,
-                          the cache seed should also be influenced by those parameters and you can pass
-                          an external string via this parameter which will be added to the seed.
-        :param limit:     Limit the number of results returned from Shotgun. In conjunction with the order
-                          parameter, this can be used to effectively cap the data set that the model
-                          is handling, allowing a user to for example show the twenty most recent notes or
-                          similar.
-        :param columns:   If columns is specified, then any leaf row in the model will have columns created where
-                          each column in the row contains the value for the corresponding field from columns. This means
-                          that the data from the loaded entity will be available field by field. Subclasses can modify
-                          this behavior by overriding _get_additional_columns.
+        :param entity_type:               Shotgun entity type to download
+        :param filters:                   List of Shotgun filters. Standard Shotgun syntax. Passing None instead
+                                          of a list of filters indicates that no shotgun data should be retrieved
+                                          and no API calls will be made.
+        :param hierarchy:                 List of grouping fields. These should be names of Shotgun
+                                          fields. If you for example want to create a list of items,
+                                          the value ``["code"]`` will be suitable. This will generate a data
+                                          model which is flat and where each item's default name is the
+                                          Shotgun name field. If you want to generate a tree where assets
+                                          are broken down by asset type, you could instead specify
+                                          ``["sg_asset_type", "code"]``.
+        :param fields:                    Fields to retrieve from Shotgun (in addition to the ones specified
+                                          in the hierarchy parameter). Standard Shotgun API syntax. If you
+                                          specify None for this parameter, Shotgun will not be called when
+                                          the _refresh_data() method is being executed.
+        :param order:                     Order clause for the Shotgun data. Standard Shotgun API syntax.
+                                          Note that this is an advanced parameter which is meant to be used
+                                          in subclassing only. The model itself will be ordered by its
+                                          default display name, and if any other type of ordering is desirable,
+                                          use for example a QProxyModel to handle this. However, knowing in which
+                                          order results will arrive from Shotgun can be beneficial if you are doing
+                                          grouping, deferred loading and aggregation of data as part of your
+                                          subclassed implementation, typically via the :meth:`_before_data_processing()` method.
+        :param seed:                      Advanced parameter. With each shotgun query being cached on disk, the model
+                                          generates a cache seed which it is using to store data on disk. Since the cache
+                                          data on disk is a reflection of a particular shotgun query, this seed is typically
+                                          generated from the various query and field parameters passed to this method. However,
+                                          in some cases when you are doing advanced subclassing, for example when you are culling
+                                          out data based on some external state, the model state does not solely depend on the
+                                          shotgun query parameters. It may also depend on some external factors. In this case,
+                                          the cache seed should also be influenced by those parameters and you can pass
+                                          an external string via this parameter which will be added to the seed.
+        :param limit:                     Limit the number of results returned from Shotgun. In conjunction with the order
+                                          parameter, this can be used to effectively cap the data set that the model
+                                          is handling, allowing a user to for example show the twenty most recent notes or
+                                          similar.
+        :param columns:                   If columns is specified, then any leaf row in the model will have columns created where
+                                          each column in the row contains the value for the corresponding field from columns. This means
+                                          that the data from the loaded entity will be available field by field. Subclasses can modify
+                                          this behavior by overriding _get_additional_columns.
+        :param additional_filter_presets: List of Shotgun filter presets to apply, e.g.
+                                          [{"preset_name": "LATEST", "latest_by": "BY_PIPELINE_STEP_NUMBER_AND_ENTITIES_CREATED_AT" }]
 
-        :returns:         True if cached data was loaded, False if not.
+        :returns:                         True if cached data was loaded, False if not.
         """
         # we are changing the query
         self.query_changed.emit()
@@ -453,6 +459,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
         self.__hierarchy = hierarchy
         self.__column_fields = columns or []
         self.__limit = limit or 0 # 0 means get all matches
+        self.__additional_filter_presets = additional_filter_presets or []
 
         # when we cache the data associated with this model, create
         # the file name and path based on several parameters.
@@ -492,6 +499,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
         params_hash.update(str(self.__fields))
         params_hash.update(str(self.__order))
         params_hash.update(str(self.__hierarchy))
+        params_hash.update(str(self.__additional_filter_presets))
 
         # now hash up the filter parameters and the seed - these are dynamic
         # values that tend to change and be data driven, so they are handled
@@ -521,6 +529,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
         self.__log_debug("Fields: %s" % self.__fields)
         self.__log_debug("Order: %s" % self.__order)
         self.__log_debug("Columns: %s" % self.__column_fields)
+        self.__log_debug("Filter Presets: %s" % self.__additional_filter_presets)
 
         self.__log_debug("First population pass: Calling _load_external_data()")
         self._load_external_data()
@@ -542,8 +551,10 @@ class ShotgunModel(QtGui.QStandardItemModel):
                                 "full SG load. Error reported: %s" % e)
 
         # set our headers
-        headers = [self.FIRST_COLUMN_HEADER] + \
-            self._get_additional_column_headers(self.__entity_type, self.__column_fields)
+        headers = [self.FIRST_COLUMN_HEADER] + self._get_additional_column_headers(
+            self.__entity_type,
+            self.__column_fields,
+        )
         self.setHorizontalHeaderLabels(headers)
 
         return loaded_cache_data
@@ -598,11 +609,14 @@ class ShotgunModel(QtGui.QStandardItemModel):
                 fields = fields + ["image"]
             fields = list(set(fields))
 
-            self.__current_work_id = self.__sg_data_retriever.execute_find(self.__entity_type,
-                                                                           self.__filters,
-                                                                           fields,
-                                                                           self.__order,
-                                                                           limit=self.__limit)
+            self.__current_work_id = self.__sg_data_retriever.execute_find(
+                self.__entity_type,
+                self.__filters,
+                fields,
+                self.__order,
+                limit=self.__limit,
+                additional_filter_presets=self.__additional_filter_presets,
+            )
 
 
     def _request_thumbnail_download(self, item, field, url, entity_type, entity_id):

--- a/python/shotgun_model/simple_shotgun_model.py
+++ b/python/shotgun_model/simple_shotgun_model.py
@@ -71,7 +71,7 @@ class SimpleShotgunModel(ShotgunModel):
                   similar.
         :param columns: List of Shotgun fields to use to populate the model columns
         :param additional_filter_presets: List of Shotgun filter presets to apply, e.g.
-                  [{"preset_name": "LATEST", "latest_by": "BY_PIPELINE_STEP_NUMBER_AND_ENTITIES_CREATED_AT" }]
+                  [{"preset_name":"LATEST","latest_by":"BY_PIPELINE_STEP_NUMBER_AND_ENTITIES_CREATED_AT"}]
         """
         filters = filters or []
         fields = fields or ["code"]

--- a/python/shotgun_model/simple_shotgun_model.py
+++ b/python/shotgun_model/simple_shotgun_model.py
@@ -42,7 +42,10 @@ class SimpleShotgunModel(ShotgunModel):
             bg_load_thumbs=True, 
             bg_task_manager=bg_task_manager)
 
-    def load_data(self, entity_type, filters=None, fields=None, order=None, limit=None, columns=None):
+    def load_data(
+        self, entity_type, filters=None, fields=None, order=None, limit=None,
+        columns=None, additional_filter_presets=None
+    ):
         """
         Loads shotgun data into the model, using the cache if possible.
         The model is not nested and the first field that is specified
@@ -67,10 +70,21 @@ class SimpleShotgunModel(ShotgunModel):
                   is handling, allowing a user to for example show the twenty most recent notes or
                   similar.
         :param columns: List of Shotgun fields to use to populate the model columns
+        :param additional_filter_presets: List of Shotgun filter presets to apply, e.g.
+                  [{"preset_name": "LATEST", "latest_by": "BY_PIPELINE_STEP_NUMBER_AND_ENTITIES_CREATED_AT" }]
         """
         filters = filters or []
         fields = fields or ["code"]
         hierarchy = [fields[0]]
         ShotgunModel._load_data(
-            self, entity_type, filters, hierarchy, fields, order=order, limit=limit, columns=columns)
+            self,
+            entity_type,
+            filters,
+            hierarchy,
+            fields,
+            order=order,
+            limit=limit,
+            columns=columns,
+            additional_filter_presets=additional_filter_presets,
+        )
         self._refresh_data()

--- a/python/shotgun_model/simple_shotgun_model.py
+++ b/python/shotgun_model/simple_shotgun_model.py
@@ -71,7 +71,7 @@ class SimpleShotgunModel(ShotgunModel):
                   similar.
         :param columns: List of Shotgun fields to use to populate the model columns
         :param additional_filter_presets: List of Shotgun filter presets to apply, e.g.
-                  [{"preset_name":"LATEST","latest_by":"BY_PIPELINE_STEP_NUMBER_AND_ENTITIES_CREATED_AT"}]
+                  ``[{"preset_name":"LATEST","latest_by":"BY_PIPELINE_STEP_NUMBER_AND_ENTITIES_CREATED_AT"}]``
         """
         filters = filters or []
         fields = fields or ["code"]


### PR DESCRIPTION
ShotgunModel and SimpleShotgunModel now accept an optional additional_filter_presets argument that is passed down to any API find calls that are run under the hood. If used, it is also incorporated into the caching mechanism's hashing routine.