### PR TITLE
#36875 removed depdenency on shotgun connection

### DIFF
--- a/python/settings/user_settings.py
+++ b/python/settings/user_settings.py
@@ -49,7 +49,7 @@ class UserSettings(object):
         # now organize various keys
         
         # studio level settings - base it on the server host name
-        _, sg_hostname, _, _, _ = urlparse.urlsplit(self.__fw.shotgun.base_url)
+        _, sg_hostname, _, _, _ = urlparse.urlsplit(self.__fw.sgtk.shotgun_url)
         self.__site_key = sg_hostname
         
         # project level settings


### PR DESCRIPTION
Switched from using `bundle.shotgun.base_url` to `bundle.sgtk.shotgun_url` which prevents a shotgun connection from being created. This helps apps which pull settings at startup - the current code effectively forces such startup code to connect to shotgun, effectively resulting in a slow startup. 