### PR TITLE
For #36702, can't generate tooltip when dot notation is more than 3 deep

### DIFF
--- a/python/shotgun_model/shotgun_model.py
+++ b/python/shotgun_model/shotgun_model.py
@@ -792,7 +792,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
             )
         elif "." in field:
             # This is scenario 2 described above.
-            _, sub_entity_type, sub_entity_field_name = field.split(".")
+            _, sub_entity_type, sub_entity_field_name = field.rsplit(".", 2)
             item.setToolTip(
                 "%s %s '%s'" % (
                     self._shotgun_globals.get_type_display_name(sub_entity_type),

--- a/python/shotgun_model/shotgun_model.py
+++ b/python/shotgun_model/shotgun_model.py
@@ -791,7 +791,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
                 )
             )
         elif "." in field:
-            # This is scenario 2 described above.
+            # This is scenario 2 described above. We only want to get the last entity and field.
             _, sub_entity_type, sub_entity_field_name = field.rsplit(".", 2)
             item.setToolTip(
                 "%s %s '%s'" % (


### PR DESCRIPTION
Tooltip generation always assumed that the entity field would always use the notation a.b.c. However, a user can use as deep a relationship as required, so it is possible to use a.b.c.d.e.f.g as well.