### PR TITLE
#35963 Allows editor widgets to be used as delegates with the shotgunmodel

### DIFF
--- a/docs/shotgun_model.rst
+++ b/docs/shotgun_model.rst
@@ -7,7 +7,7 @@ Introduction
 ======================================
 
 The shotgun data model helps you build responsive, data rich applications quickly and leverage
-QT's build in model/view framework
+QT's built-in model/view framework
 
 .. image:: images/model_overview.png
 

--- a/python/shotgun_model/shotgun_model.py
+++ b/python/shotgun_model/shotgun_model.py
@@ -384,7 +384,7 @@ class ShotgunModel(QtGui.QStandardItemModel):
 
     def _load_data(
         self, entity_type, filters, hierarchy, fields, order=None, seed=None, limit=None,
-        columns=None, editable_columns=None, additional_filter_presets=None
+        columns=None, additional_filter_presets=None, editable_columns=None
     ):
         """
         This is the main method to use to configure the model. You basically
@@ -436,13 +436,13 @@ class ShotgunModel(QtGui.QStandardItemModel):
                                           parameter, this can be used to effectively cap the data set that the model
                                           is handling, allowing a user to for example show the twenty most recent notes or
                                           similar.
-        :param columns:                   If columns is specified, then any leaf row in the model will have columns created where
+        :param list columns:              If columns is specified, then any leaf row in the model will have columns created where
                                           each column in the row contains the value for the corresponding field from columns. This means
                                           that the data from the loaded entity will be available field by field. Subclasses can modify
                                           this behavior by overriding _get_additional_columns.
-        :param editable_columns:          A subset of ``columns`` that will be editable in views that use this model.
         :param additional_filter_presets: List of Shotgun filter presets to apply, e.g.
                                           ``[{"preset_name":"LATEST","latest_by":"BY_PIPELINE_STEP_NUMBER_AND_ENTITIES_CREATED_AT"}]``
+        :param list editable_columns:     A subset of ``columns`` that will be editable in views that use this model.
 
         :returns:                         True if cached data was loaded, False if not.
         """
@@ -462,6 +462,11 @@ class ShotgunModel(QtGui.QStandardItemModel):
         self.__editable_fields = editable_columns or []
         self.__limit = limit or 0 # 0 means get all matches
         self.__additional_filter_presets = additional_filter_presets
+
+        # make sure `editable_fields` is a subset of `column_fields`
+        if not set(self.__editable_fields).issubset(set(self.__column_fields)):
+            raise tank.TankError(
+                "The `editable_fields` argument is not a subset of `column_fields`.")
 
         # when we cache the data associated with this model, create
         # the file name and path based on several parameters.

--- a/python/shotgun_model/shotgun_model.py
+++ b/python/shotgun_model/shotgun_model.py
@@ -400,6 +400,20 @@ class ShotgunModel(QtGui.QStandardItemModel):
         If you want to refresh the data contained in the model (which you typically
         want to), call the :meth:`_refresh_data()` method.
 
+        .. code-block:: python
+
+            # Example call from a subclass of ShotgunModel that displays assets.
+            # Additional "code" and " description" columns will be displayed,
+            # and the "description" column will be editable.
+            self._load_data(
+                "Asset",                            # entity_type
+                [],                                 # filters
+                ["sg_asset_type", "code"],          # hierarchy
+                ["description"],                    # fields
+                columns=["code", "description"],    # additional columns to display
+                editable_columns=["description"],
+            )
+
         :param entity_type:               Shotgun entity type to download
         :param filters:                   List of Shotgun filters. Standard Shotgun syntax. Passing None instead
                                           of a list of filters indicates that no shotgun data should be retrieved

--- a/python/shotgun_model/shotgun_standard_item.py
+++ b/python/shotgun_model/shotgun_standard_item.py
@@ -23,7 +23,7 @@ class ShotgunStandardItem(QtGui.QStandardItem):
 
     ########################################################################################
     # helper methods
-    
+
     def get_sg_data(self):
         """
         Retrieves the shotgun data associated with this item.

--- a/python/shotgun_model/simple_shotgun_model.py
+++ b/python/shotgun_model/simple_shotgun_model.py
@@ -44,7 +44,7 @@ class SimpleShotgunModel(ShotgunModel):
 
     def load_data(
         self, entity_type, filters=None, fields=None, order=None, limit=None,
-        columns=None, editable_columns=None, additional_filter_presets=None
+        columns=None, additional_filter_presets=None, editable_columns=None
     ):
         """
         Loads shotgun data into the model, using the cache if possible.
@@ -69,10 +69,10 @@ class SimpleShotgunModel(ShotgunModel):
                   parameter, this can be used to effectively cap the data set that the model
                   is handling, allowing a user to for example show the twenty most recent notes or
                   similar.
-        :param columns: List of Shotgun fields to use to populate the model columns
-        :param editable_columns: A subset of ``columns`` that will be editable in views that use this model.
+        :param list columns: List of Shotgun fields names to use to populate the model columns
         :param additional_filter_presets: List of Shotgun filter presets to apply, e.g.
                   ``[{"preset_name":"LATEST","latest_by":"BY_PIPELINE_STEP_NUMBER_AND_ENTITIES_CREATED_AT"}]``
+        :param list editable_columns: A subset of ``columns`` that will be editable in views that use this model.
         """
         filters = filters or []
         fields = fields or ["code"]
@@ -86,7 +86,7 @@ class SimpleShotgunModel(ShotgunModel):
             order=order,
             limit=limit,
             columns=columns,
-            editable_columns=editable_columns,
             additional_filter_presets=additional_filter_presets,
+            editable_columns=editable_columns,
         )
         self._refresh_data()

--- a/python/shotgun_model/simple_shotgun_model.py
+++ b/python/shotgun_model/simple_shotgun_model.py
@@ -44,7 +44,7 @@ class SimpleShotgunModel(ShotgunModel):
 
     def load_data(
         self, entity_type, filters=None, fields=None, order=None, limit=None,
-        columns=None, additional_filter_presets=None
+        columns=None, editable_columns=None, additional_filter_presets=None
     ):
         """
         Loads shotgun data into the model, using the cache if possible.
@@ -70,6 +70,7 @@ class SimpleShotgunModel(ShotgunModel):
                   is handling, allowing a user to for example show the twenty most recent notes or
                   similar.
         :param columns: List of Shotgun fields to use to populate the model columns
+        :param editable_columns: A subset of ``columns`` that will be editable in views that use this model.
         :param additional_filter_presets: List of Shotgun filter presets to apply, e.g.
                   ``[{"preset_name":"LATEST","latest_by":"BY_PIPELINE_STEP_NUMBER_AND_ENTITIES_CREATED_AT"}]``
         """
@@ -85,6 +86,7 @@ class SimpleShotgunModel(ShotgunModel):
             order=order,
             limit=limit,
             columns=columns,
+            editable_columns=editable_columns,
             additional_filter_presets=additional_filter_presets,
         )
         self._refresh_data()


### PR DESCRIPTION
This changes adds the ability to specify columns in the SG model whose items should have the `ItemIsEditable` flag set. This allows for the item to be edited within views backed by the model.