### PR TITLE
#37467 Updates field editable/visible to use project id based schema caches

### DIFF
--- a/python/shotgun_globals/cached_schema.py
+++ b/python/shotgun_globals/cached_schema.py
@@ -103,16 +103,17 @@ class CachedShotgunSchema(QtCore.QObject):
 
     def _get_current_project_id(self):
         """
-        Gets the project id associated with the current context, or 0
-        if operating in a site-level context.
+        Return the id of the current project.
 
-        :returns:   int
+        :returns: The project id associated with the current context, or ``None``
+            if operating in a site-level context.
+        :rtype: ``int`` or ``None``
         """
-        # The project id is going to be passed around by signals, as
-        # well as being passed to a core hook in some situations. As
-        # a result, we need it to always be an int value.
+
         if self._bundle.tank.pipeline_configuration.is_site_configuration():
-            project_id = 0
+            # site configuration (no project id). Return None which is
+            # consistent with core.
+            project_id = None
         else:
             project_id = self._bundle.tank.pipeline_configuration.get_project_id()
 

--- a/python/shotgun_globals/cached_schema.py
+++ b/python/shotgun_globals/cached_schema.py
@@ -744,8 +744,10 @@ class CachedShotgunSchema(QtCore.QObject):
 
         :param str sg_entity_type: the entity type
         :param str field_name: the field name to check editibility
-        :param project_id:  The id of the project.
-                            If None, the current context's project will be used.
+        :param project_id:  The project Entity id. If None, the current
+                            context's project will be used, or the "site"
+                            cache location will be returned if the current
+                            context does not have an associated project.
 
         :returns: ``True`` if the field is ediable, ``False`` otherwise.
         """
@@ -777,8 +779,10 @@ class CachedShotgunSchema(QtCore.QObject):
 
         :param sg_entity_type: the entity type
         :param field_name: the field name to check visibility
-        :param project_id:  The id of the project.
-                            If None, the current context's project will be used.
+        :param project_id:  The project Entity id. If None, the current
+                            context's project will be used, or the "site"
+                            cache location will be returned if the current
+                            context does not have an associated project.
 
         :returns: ``True`` if the field is visible, ``False`` otherwise.
         """

--- a/python/shotgun_globals/cached_schema.py
+++ b/python/shotgun_globals/cached_schema.py
@@ -738,43 +738,63 @@ class CachedShotgunSchema(QtCore.QObject):
         return status_color
 
     @classmethod
-    def field_is_editable(cls, sg_entity_type, field_name):
+    def field_is_editable(cls, sg_entity_type, field_name, project_id=None):
         """
         Returns a boolean identifying the editability of the entity's field.
 
         :param str sg_entity_type: the entity type
         :param str field_name: the field name to check editibility
+        :param project_id:  The id of the project.
+                            If None, the current context's project will be used.
 
         :returns: ``True`` if the field is ediable, ``False`` otherwise.
         """
         self = cls.__get_instance()
-        self._check_schema_refresh(sg_entity_type, field_name)
 
-        if sg_entity_type in self._type_schema and field_name in self._field_schema[sg_entity_type]:
-            data = self._field_schema[sg_entity_type][field_name]
+        project_id = project_id or self._get_current_project_id()
+        self._check_schema_refresh(sg_entity_type, field_name, project_id=project_id)
+
+        # make sure the project id is found in each of the type and file schemas
+        # and that the entity type and field name are found in their respective
+        # project caches
+        if (project_id in self._type_schema and
+            project_id in self._field_schema and
+            sg_entity_type in self._type_schema[project_id] and
+            field_name in self._field_schema[project_id][sg_entity_type]):
+
+            data = self._field_schema[project_id][sg_entity_type][field_name]
             try:
                 return data["editable"]["value"]
             except KeyError:
                 raise ValueError("Could not determine editability from the schema.")
 
-
         raise ValueError("Could not find the schema for %s.%s" % (sg_entity_type, field_name))
 
     @classmethod
-    def field_is_visible(cls, sg_entity_type, field_name):
+    def field_is_visible(cls, sg_entity_type, field_name, project_id=None):
         """
         Returns a boolean identifying the visibility of the entity's field.
 
         :param sg_entity_type: the entity type
         :param field_name: the field name to check visibility
+        :param project_id:  The id of the project.
+                            If None, the current context's project will be used.
 
         :returns: ``True`` if the field is visible, ``False`` otherwise.
         """
         self = cls.__get_instance()
-        self._check_schema_refresh(sg_entity_type, field_name)
+        project_id = project_id or self._get_current_project_id()
+        self._check_schema_refresh(sg_entity_type, field_name, project_id=project_id)
 
-        if sg_entity_type in self._type_schema and field_name in self._field_schema[sg_entity_type]:
-            data = self._field_schema[sg_entity_type][field_name]
+        # make sure the project id is found in each of the type and file schemas
+        # and that the entity type and field name are found in their respective
+        # project caches
+        if (project_id in self._type_schema and
+            project_id in self._field_schema and
+            sg_entity_type in self._type_schema[project_id] and
+            field_name in self._field_schema[project_id][sg_entity_type]):
+
+            data = self._field_schema[project_id][sg_entity_type][field_name]
             try:
                 return data["visible"]["value"]
             except KeyError:


### PR DESCRIPTION
This changes updates the `field_is_editable` and `field_is_visible` methods to use the new style schema caches which key off of the `project_id`. 