### PR TITLE
Doc tweaks for hierarchy model limitations.

### DIFF
--- a/python/shotgun_model/shotgun_hierarchy_item.py
+++ b/python/shotgun_model/shotgun_hierarchy_item.py
@@ -122,16 +122,16 @@ class ShotgunHierarchyItem(ShotgunStandardItem):
         The dictionary also stores a ``type`` key whose value is the type of
         entity being targeted.
 
-        A common usage of this is to respond to selection changed signals
-        on a view showing a shotgun hierarchy. For example, the data returned
-        can be fed to a separate shotgun model view.
+        A common usage of this is to respond to selection-changed signals
+        on a view showing a Shotgun hierarchy. For example, the data returned
+        can be fed to a separate Shotgun model view.
 
         Example usage::
 
             target_entities = selected_item.target_entities()
 
             sg_model.load_data(
-                target_entities.get("type"),
+                target_entities["type"],
                 additional_filter_presets=target_entities.get("additional_filter_presets"),
             )
             

--- a/python/shotgun_model/shotgun_hierarchy_item.py
+++ b/python/shotgun_model/shotgun_hierarchy_item.py
@@ -112,8 +112,8 @@ class ShotgunHierarchyItem(ShotgunStandardItem):
         ``target_entities``.
 
         This dictionary stores information that can be used to query the
-        entities targeted when the containing hierarchy model was created.
-        It includes a key called `additional_filter_presets` with a value
+        entities targeted when the containing hierarchy model was created. 
+        It includes a key called ``additional_filter_presets`` with a value
         that can be provided to the shotgun python-api's ``find()`` call to
         tell the server exactly which entities exist under this item's branch
         in the hierarchy. The value is a list of dictionaries with server-side
@@ -122,21 +122,19 @@ class ShotgunHierarchyItem(ShotgunStandardItem):
         The dictionary also stores a ``type`` key whose value is the type of
         entity being targeted.
 
-        An example value returned by this method::
+        A common usage of this is to respond to selection changed signals
+        on a view showing a shotgun hierarchy. For example, the data returned
+        can be fed to a separate shotgun model view.
 
-            'target_entities': {
-                'additional_filter_presets': [
-                    {
-                        'path': '/Project/65/Asset/sg_asset_type/Character',
-                        'preset_name': 'NAV_ENTRIES',
-                        'seed': {
-                            'field': 'entity',
-                            'type': 'Version'
-                        }
-                    }
-                ],
-                'type': 'Version'
-            },
+        Example usage::
+
+            target_entities = selected_item.target_entities()
+
+            sg_model.load_data(
+                target_entities.get("type"),
+                additional_filter_presets=target_entities.get("additional_filter_presets"),
+            )
+            
         """
 
         data = self.data()

--- a/python/shotgun_model/shotgun_hierarchy_model.py
+++ b/python/shotgun_model/shotgun_hierarchy_model.py
@@ -209,7 +209,10 @@ class ShotgunHierarchyModel(ShotgunQueryModel):
         :param str seed_entity_field: This is a string that corresponds to the
             field on an entity used to seed the hierarchy. For example, a value
             of ``Version.entity`` would cause the model to display a hierarchy
-            where the leaves match the entity value of Version entities.
+            where the leaves match the entity value of Version entities. 
+            
+            NOTE: This value is currently limited to either ``Version.entity``
+            or ``PublishedFile.entity``
 
         :param str path: The path to the root of the hierarchy to display.
             This corresponds to the ``path`` argument of the

--- a/python/shotgun_model/simple_shotgun_hierarchy_model.py
+++ b/python/shotgun_model/simple_shotgun_hierarchy_model.py
@@ -40,6 +40,9 @@ class SimpleShotgunHierarchyModel(ShotgunHierarchyModel):
             of ``Version.entity`` would cause the model to display a hierarchy
             where the leaves match the entity value of Version entities.
 
+            NOTE: This value is currently limited to either ``Version.entity``
+            or ``PublishedFile.entity``
+
         :param str path: The path to the root of the hierarchy to display.
             This corresponds to the ``path`` argument of the
             :meth:`~shotgun-api3:shotgun_api3.Shotgun.nav_expand()` api method.


### PR DESCRIPTION
A client attempted to use the new API with an unsupported seed. This cleans up the docs to make the limitations clearer. Also hides the `NAV_ENTRIES` additional filter type from the docs to prevent direct usage until it is officially public.