### PR TITLE
For #40555: Only uses deleteLater if we're in Qt4.

### DIFF
--- a/python/shotgun_model/shotgun_hierarchy_model.py
+++ b/python/shotgun_model/shotgun_hierarchy_model.py
@@ -22,9 +22,8 @@ from .shotgun_hierarchy_item import ShotgunHierarchyItem
 from .shotgun_query_model import ShotgunQueryModel
 from .data_handler_nav import ShotgunNavDataHandler
 from .util import sanitize_for_qt_model
-from ..utils import safe_delete_later
 
-
+utils = sgtk.platform.current_bundle().import_module("utils")
 logger = sgtk.platform.get_logger(__name__)
 
 
@@ -204,7 +203,7 @@ class ShotgunHierarchyModel(ShotgunQueryModel):
                 "Model item refreshed: %s", item.data(self.parent()._SG_ITEM_UNIQUE_ID)
             )
             self.parent()._node_refreshed.disconnect(self._node_refreshed)
-            safe_delete_later(self)
+            utils.safe_delete_later(self)
 
             # Try again to async deep load the node and the next tokens.
             self.parent().async_item_from_paths(self._path_to_refresh)

--- a/python/shotgun_model/shotgun_hierarchy_model.py
+++ b/python/shotgun_model/shotgun_hierarchy_model.py
@@ -22,6 +22,7 @@ from .shotgun_hierarchy_item import ShotgunHierarchyItem
 from .shotgun_query_model import ShotgunQueryModel
 from .data_handler_nav import ShotgunNavDataHandler
 from .util import sanitize_for_qt_model
+from ..utils import safe_delete_later
 
 
 logger = sgtk.platform.get_logger(__name__)
@@ -203,13 +204,8 @@ class ShotgunHierarchyModel(ShotgunQueryModel):
                 "Model item refreshed: %s", item.data(self.parent()._SG_ITEM_UNIQUE_ID)
             )
             self.parent()._node_refreshed.disconnect(self._node_refreshed)
-            # We've seen problems in Qt5 with deleteLater causing
-            # garbage collection of Qt objects out from under Python
-            # objects that still have active references. If we're not
-            # in Qt4, then we're going to let Qt/Python decide when to
-            # clean up instead of forcing it ourselves.
-            if QtCore.__version__.startswith("4."):
-                self.deleteLater()
+            safe_delete_later(self)
+
             # Try again to async deep load the node and the next tokens.
             self.parent().async_item_from_paths(self._path_to_refresh)
 

--- a/python/shotgun_model/shotgun_hierarchy_model.py
+++ b/python/shotgun_model/shotgun_hierarchy_model.py
@@ -23,7 +23,6 @@ from .shotgun_query_model import ShotgunQueryModel
 from .data_handler_nav import ShotgunNavDataHandler
 from .util import sanitize_for_qt_model
 
-utils = sgtk.platform.current_bundle().import_module("utils")
 logger = sgtk.platform.get_logger(__name__)
 
 
@@ -203,6 +202,7 @@ class ShotgunHierarchyModel(ShotgunQueryModel):
                 "Model item refreshed: %s", item.data(self.parent()._SG_ITEM_UNIQUE_ID)
             )
             self.parent()._node_refreshed.disconnect(self._node_refreshed)
+            utils = sgtk.platform.current_bundle().import_module("utils")
             utils.safe_delete_later(self)
 
             # Try again to async deep load the node and the next tokens.

--- a/python/shotgun_model/shotgun_hierarchy_model.py
+++ b/python/shotgun_model/shotgun_hierarchy_model.py
@@ -203,7 +203,13 @@ class ShotgunHierarchyModel(ShotgunQueryModel):
                 "Model item refreshed: %s", item.data(self.parent()._SG_ITEM_UNIQUE_ID)
             )
             self.parent()._node_refreshed.disconnect(self._node_refreshed)
-            self.deleteLater()
+            # We've seen problems in Qt5 with deleteLater causing
+            # garbage collection of Qt objects out from under Python
+            # objects that still have active references. If we're not
+            # in Qt4, then we're going to let Qt/Python decide when to
+            # clean up instead of forcing it ourselves.
+            if QtCore.__version__.startswith("4."):
+                self.deleteLater()
             # Try again to async deep load the node and the next tokens.
             self.parent().async_item_from_paths(self._path_to_refresh)
 

--- a/python/task_manager/background_task_manager.py
+++ b/python/task_manager/background_task_manager.py
@@ -160,7 +160,7 @@ class BackgroundTaskManager(QtCore.QObject):
         for thread in self._all_threads:
             thread.shut_down()
         self._available_threads = []
-        # self._all_threads = []
+        self._all_threads = []
 
         # Shut down the dispatcher thread
         self._results_dispatcher.shut_down()

--- a/python/task_manager/background_task_manager.py
+++ b/python/task_manager/background_task_manager.py
@@ -160,7 +160,7 @@ class BackgroundTaskManager(QtCore.QObject):
         for thread in self._all_threads:
             thread.shut_down()
         self._available_threads = []
-        self._all_threads = []
+        # self._all_threads = []
 
         # Shut down the dispatcher thread
         self._results_dispatcher.shut_down()

--- a/python/task_manager/worker_thread.py
+++ b/python/task_manager/worker_thread.py
@@ -67,7 +67,7 @@ class WorkerThread(QtCore.QThread):
         """
         The main thread run function.  Loops over tasks until asked to exit.
         """
-        while True:
+        while True and self._results_dispatcher is not None:
             # get the next task to process:
             task_to_process = None
             self._mutex.lock()

--- a/python/utils/__init__.py
+++ b/python/utils/__init__.py
@@ -9,3 +9,4 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from .color import color_mix
+from .qt import safe_delete_later

--- a/python/utils/qt.py
+++ b/python/utils/qt.py
@@ -8,8 +8,6 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from sgtk.platform.qt import QtCore
-
 def safe_delete_later(widget):
     """
     Will call the deleteLater method on the given widget, but only if
@@ -19,6 +17,7 @@ def safe_delete_later(widget):
 
     :param widget: The widget to potentially call deleteLater on.
     """
+    from sgtk.platform.qt import QtCore
     if QtCore.__version__.startswith("4."):
         widget.deleteLater()
 

--- a/python/utils/qt.py
+++ b/python/utils/qt.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2017 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+from sgtk.platform.qt import QtCore
+
+def safe_delete_later(widget):
+    """
+    Will call the deleteLater method on the given widget, but only if
+    running in a Qt4 environment. This allows us to proactively delete
+    widgets in Qt4, but protects us from garbage collection issues
+    associated with doing the same in PySide2/Qt5.
+
+    :param widget: The widget to potentially call deleteLater on.
+    """
+    if QtCore.__version__.startswith("4."):
+        widget.deleteLater()
+


### PR DESCRIPTION
We're seeing a lot of problems related to garbage collection in PySide2/Qt5 when deleteLater is used. These issues result in crashes on DCC close in some cases, but also errors on app close even when the DCC isn't being closed.