### PR TITLE
43294 cache sharing

### DIFF
--- a/python/shotgun_data/shotgun_data_retriever.py
+++ b/python/shotgun_data/shotgun_data_retriever.py
@@ -957,9 +957,19 @@ class ShotgunDataRetriever(QtCore.QObject):
         second_folder = hash_str[2:4]
 
         # Establish the cache path directory
-        cache_path_items = [
-            bundle.cache_location, "thumbs", first_folder, second_folder
-        ]
+        # If possible we share thumbnails at the site cache level.
+        # Site cache location was introduced in tk-core > v0.18.118, to not
+        # introduce a dependency on a tk-core release, we simply check if the method
+        # is available or not.
+        if hasattr(bundle, "site_cache_location"):
+            cache_path_items = [
+                bundle.site_cache_location, "thumbs", first_folder, second_folder
+            ]
+        else:
+            # Fallback to caching per project/pipeline config/plugin id.
+            cache_path_items = [
+                bundle.cache_location, "thumbs", first_folder, second_folder
+            ]
 
         cached_thumb_exists = False
         # If we were only asked to give back a directory path then we can

--- a/python/shotgun_model/shotgun_hierarchy_model.py
+++ b/python/shotgun_model/shotgun_hierarchy_model.py
@@ -625,10 +625,20 @@ class ShotgunHierarchyModel(ShotgunQueryModel):
         seed_entity_field_path = os.path.join(
             *self._seed_entity_field.split("."))
 
-        # organize files on disk based on the seed_entity field path segment and
+        # Organize files on disk based on the seed_entity field path segment and
         # then param and entity field hashes
+
+        # Try to share the cache at the site level which was introduced in tk-core
+        # > 0.18.118.
+        # If not available, fallback on per project/pipeline config/plugin id
+        # caching.
+        if hasattr(self._bundle, "site_cache_location"):
+            cache_location = self._bundle.site_cache_location
+        else:
+            cache_location = self._bundle.cache_location
+
         data_cache_path = os.path.join(
-            self._bundle.cache_location,
+            cache_location,
             "sg_nav",
             seed_entity_field_path,
             params_hash.hexdigest(),

--- a/python/shotgun_model/shotgun_model.py
+++ b/python/shotgun_model/shotgun_model.py
@@ -721,11 +721,19 @@ class ShotgunModel(ShotgunQueryModel):
         filter_hash.update(str(self.__additional_filter_presets))
         params_hash.update(str(cache_seed))
 
-        # organize files on disk based on entity type and then filter hash
+        # Organize files on disk based on entity type and then filter hash
         # keep extension names etc short in order to stay away from MAX_PATH
         # on windows.
+        # Try to share the cache at the site level which was introduced in tk-core
+        # > 0.18.118.
+        # If not available, fallback on per project/pipeline config/plugin id
+        # caching.
+        if hasattr(self._bundle, "site_cache_location"):
+            cache_location = self._bundle.site_cache_location
+        else:
+            cache_location = self._bundle.cache_location
         data_cache_path = os.path.join(
-            self._bundle.cache_location,
+            cache_location,
             "sg",
             self.__entity_type,
             params_hash.hexdigest(),


### PR DESCRIPTION
Allow to share data cache location for thumbnails and SG queries.

Check if the`Bundle.site_cache_location` which was just introduced in tk-core is available, leverage it if so, fallback on the caching per project/pipeline config/plugin id if not.

