### PR TITLE
For #39289, fix for tk-core < 0.18.119

### DIFF
--- a/framework.py
+++ b/framework.py
@@ -90,9 +90,13 @@ class ShotgunUtilsFramework(sgtk.platform.Framework):
 
             # Clean up the site cache and the project cache locations, only consider
             # folders specified in _CLEANUP_FOLDERS
-            cache_locations = [
-                os.path.join(self.site_cache_location, folder) for folder in self._CLEANUP_FOLDERS
-            ]
+            cache_locations = []
+            if hasattr(self, "site_cache_location"):
+                # This was introduced in tk-core v0.18.119 but we don't have an
+                # explicit dependency to it, so check if the attribute is available.
+                cache_locations.extend([
+                    os.path.join(self.site_cache_location, folder) for folder in self._CLEANUP_FOLDERS
+                ])
             cache_locations.extend([
                 os.path.join(self.cache_location, folder) for folder in self._CLEANUP_FOLDERS
             ])


### PR DESCRIPTION
Fix for data cleanup if tk-core version is older than v0.18.119 where `site_cache_location` was added:
* Check if `site_cache_location` is available before trying to use it.