### PR TITLE
`log_timing` does not properly wrap methods resulting in messy tracebacks

### DIFF
--- a/python/shotgun_model/data_handler.py
+++ b/python/shotgun_model/data_handler.py
@@ -17,26 +17,9 @@ import time
 
 # toolkit imports
 import sgtk
-from sgtk.platform.qt import QtCore, QtGui
 
 from .errors import ShotgunModelDataError
 from .data_handler_cache import ShotgunDataHandlerCache
-
-def log_timing(func):
-    """
-    Decorator that times and logs the execution of a method.
-    Borrowed from 0.18.
-    """
-    def wrapper(self, *args, **kwargs):
-        time_before = time.time()
-        try:
-            response = func(self, *args, **kwargs)
-        finally:
-            time_spent = time.time() - time_before
-            # log to special timing logger
-            self._bundle.log_debug("ShotgunDataHandler.%s took %fs" % (func.__name__, time_spent))
-        return response
-    return wrapper
 
 
 class ShotgunDataHandler(object):
@@ -116,7 +99,7 @@ class ShotgunDataHandler(object):
         """
         return self._cache is not None
 
-    @log_timing
+    @sgtk.LogManager.log_timing
     def remove_cache(self):
         """
         Removes the associated cache file from disk
@@ -141,7 +124,7 @@ class ShotgunDataHandler(object):
 
         return True
 
-    @log_timing
+    @sgtk.LogManager.log_timing
     def load_cache(self):
         """
         Loads a cache from disk into memory
@@ -181,7 +164,7 @@ class ShotgunDataHandler(object):
         self._log_debug("Unloading in-memory cache for %s" % self)
         self._cache = None
 
-    @log_timing
+    @sgtk.LogManager.log_timing
     def save_cache(self):
         """
         Saves the current cache to disk.
@@ -253,7 +236,7 @@ class ShotgunDataHandler(object):
 
         return self._cache.get_entry_by_uid(unique_id)
 
-    @log_timing
+    @sgtk.LogManager.log_timing
     def generate_child_nodes(self, unique_id, parent_object, factory_fn):
         """
         Generate nodes recursively from the data set
@@ -392,4 +375,3 @@ class ShotgunDataHandler(object):
             sg_data = time.mktime(sg_data.timetuple())
 
         return sg_data
-

--- a/python/shotgun_model/data_handler_find.py
+++ b/python/shotgun_model/data_handler_find.py
@@ -9,10 +9,11 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 import gc
 
-from .data_handler import ShotgunDataHandler, log_timing
+from .data_handler import ShotgunDataHandler
 from .errors import ShotgunModelDataError
 from .data_handler_cache import ShotgunDataHandlerCache
 from .util import compare_shotgun_data
+import sgtk
 
 
 class ShotgunFindDataHandler(ShotgunDataHandler):
@@ -24,7 +25,10 @@ class ShotgunFindDataHandler(ShotgunDataHandler):
     shotgun find query is stored in the cache file.
     """
 
-    def __init__(self, entity_type, filters, order, hierarchy, fields, download_thumbs, limit, additional_filter_presets, cache_path):
+    def __init__(
+        self, entity_type, filters, order, hierarchy, fields, download_thumbs,
+        limit, additional_filter_presets, cache_path
+    ):
         """
         :param entity_type:               Shotgun entity type to download
         :param filters:                   List of Shotgun filters. Standard Shotgun syntax.
@@ -40,10 +44,11 @@ class ShotgunFindDataHandler(ShotgunDataHandler):
                                           the ones specified in the hierarchy parameter).
         :param download_thumbs:           Boolean to indicate if this model should attempt
                                           to download and process thumbnails for the downloaded data.
-        :param limit:                     Limit the number of results returned from Shotgun. In conjunction with the order
+        :param limit:                     Limit the number of results returned from Shotgun. In conjunction with the
+                                          order
                                           parameter, this can be used to effectively cap the data set that the model
-                                          is handling, allowing a user to for example show the twenty most recent notes or
-                                          similar.
+                                          is handling, allowing a user to for example show the twenty most recent note
+                                          or similar.
         :param additional_filter_presets: List of Shotgun filter presets to apply, e.g.
                                           ``[{"preset_name":"LATEST","latest_by":"BY_PIPELINE_STEP_NUMBER_AND_ENTITIES_CREATED_AT"}]``
         :param cache_path:                Path to cache file location
@@ -138,7 +143,7 @@ class ShotgunFindDataHandler(ShotgunDataHandler):
 
         return request_id
 
-    @log_timing
+    @sgtk.LogManager.log_timing
     def update_data(self, sg_data):
         """
         The counterpart to :meth:`generate_data_request`. When the data
@@ -353,5 +358,3 @@ class ShotgunFindDataHandler(ShotgunDataHandler):
             return "/%s" % unique_key
         else:
             return "%s/%s" % (parent_unique_key, unique_key)
-
-

--- a/python/shotgun_model/data_handler_nav.py
+++ b/python/shotgun_model/data_handler_nav.py
@@ -9,12 +9,10 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import copy
-import gc
 
-from .data_handler import ShotgunDataHandler, log_timing
+from .data_handler import ShotgunDataHandler
 from .errors import ShotgunModelDataError
-from .data_item import ShotgunItemData
-from .data_handler_cache import ShotgunDataHandlerCache
+import sgtk
 
 
 class ShotgunNavDataHandler(ShotgunDataHandler):
@@ -91,7 +89,7 @@ class ShotgunNavDataHandler(ShotgunDataHandler):
 
         return worker_id
 
-    @log_timing
+    @sgtk.LogManager.log_timing
     def update_data(self, sg_data):
         """
         The counterpart to :meth:`generate_data_request`. When the data
@@ -243,6 +241,3 @@ class ShotgunNavDataHandler(ShotgunDataHandler):
         self._log_debug("    Number of modified records: %d" % num_modifications)
 
         return diff_list
-
-
-


### PR DESCRIPTION
We're switching to tk-core's version, since the framework has required use of 0.18 for a while now and tk-core has the correct implementation.