### PR TITLE
For #38483, fix for deleting items.

### DIFF
--- a/python/shotgun_model/shotgun_query_model.py
+++ b/python/shotgun_model/shotgun_query_model.py
@@ -810,8 +810,12 @@ class ShotgunQueryModel(QtGui.QStandardItemModel):
         parent_model_item = item.parent()
 
         if parent_model_item:
-            # remove entire row that item belongs to
-            parent_model_item.removeRow(item.row())
+            # remove entire row that item belongs to.
+            # we are the owner of the data so we just do a `takeRow` and not a
+            # `removeRow` to prevent the model to delete the data. Because we
+            # don't keep any reference to the item, it will be garbage collected
+            # if not already done.
+            parent_model_item.takeRow(item.row())
 
     def _log_debug(self, msg):
         """


### PR DESCRIPTION
Fix for crashes when removing items in Nuke:

Use `takeRow` instead of `deleteRow` when removing items to prevent RuntimeError: Internal C++ object (ShotgunStandardItem) already deleted errors, the item being already garbage collected in some cases (e.g. in Nuke).