### PR TITLE
#47017 Fixes bug where data_refreshed always returns true

### DIFF
--- a/python/shotgun_model/shotgun_query_model.py
+++ b/python/shotgun_model/shotgun_query_model.py
@@ -1035,4 +1035,4 @@ class ShotgunQueryModel(QtGui.QStandardItemModel):
             self._log_debug("...diffs applied!")
 
         # and emit completion signal
-        self.data_refreshed.emit(modified_items > 0)
+        self.data_refreshed.emit(len(modified_items) > 0)


### PR DESCRIPTION
Brings out this fix as a separate ticket and PR so that it doesn't get stuck in a feature branch for too long: https://github.com/shotgunsoftware/tk-framework-shotgunutils/pull/82/files#diff-d442a3297316abbae14a00adf3457696R1034

This fixes an issue where the `data_refreshed` signal was always returning a `True` flag, thereby indicating that data had changed, effectively meaning we were generating many false positives. 