### PR TITLE
#47089 Adjustments to signal policy

### DIFF
--- a/python/external_config/external_config_loader.py
+++ b/python/external_config/external_config_loader.py
@@ -153,8 +153,9 @@ class ExternalConfigurationLoader(QtCore.QObject):
         # is emitted even if this method is called multiple times
         # in rapid succession.
         #
-        for (task_id, task_project_id) in self._task_ids.iteritems():
-            if task_project_id == project_id:
+        # note: not using a generator since we are deleting in the loop
+        for task_id in self._task_ids.keys():
+            if self._task_ids[task_id] == project_id:
                 logger.debug(
                     "Discarding existing request_configurations request for project %s" % project_id
                 )

--- a/python/external_config/external_config_loader.py
+++ b/python/external_config/external_config_loader.py
@@ -142,8 +142,24 @@ class ExternalConfigurationLoader(QtCore.QObject):
         Emits a ``configurations_loaded`` signal when the configurations
         have been loaded.
 
+        .. note:: If this method is called multiple times in quick succession, only
+                  a single ``configurations_loaded`` signal will be emitted, belonging
+                  to the last request.
+
         :param project_id: Project to request configurations for.
         """
+        # First of all, remove any existing requests for this project from
+        # our internal task tracker. This will ensure that only one signal
+        # is emitted even if this method is called multiple times
+        # in rapid succession.
+        #
+        for (task_id, task_project_id) in self._task_ids.iteritems():
+            if task_project_id == project_id:
+                logger.debug(
+                    "Discarding existing request_configurations request for project %s" % project_id
+                )
+                del self._task_ids[task_id]
+
         # load existing cache file if it exists
         config_cache_key = {
             "project": project_id,
@@ -184,6 +200,7 @@ class ExternalConfigurationLoader(QtCore.QObject):
                     "state_hash": self._config_state.get_hash()
                 }
             )
+
             self._task_ids[unique_id] = project_id
 
     def _execute_get_configurations(self, project_id, state_hash):


### PR DESCRIPTION
Tweak to the behaviour of the `request_configurations()` method -- if called multiple times in rapid succession, only a single signal will be emitted. Any queued up or in-progress signals are basically discarded when `request_configurations()` is called.