### PR TITLE
SG-6836: Fixes a bug that manifested when a model hard_refresh was called

### DIFF
--- a/python/shotgun_model/data_handler_find.py
+++ b/python/shotgun_model/data_handler_find.py
@@ -176,8 +176,9 @@ class ShotgunFindDataHandler(ShotgunDataHandler):
 
         new_cache = ShotgunDataHandlerCache()
 
+        # If we don't already have a cache, we can continue on here by just populating
+        # our new cache with the necessary data.
         if self._cache is None:
-            # raise ShotgunModelDataError("No data currently loaded in memory!")
             self._cache = new_cache
 
         if self._cache.size == 0:
@@ -295,7 +296,7 @@ class ShotgunFindDataHandler(ShotgunDataHandler):
             })
             num_deletes += 1
 
-        # lastly swap the new for the old
+        # Lastly, swap in the new cache if it's not already been done.
         if self._cache is not new_cache:
             self._cache = None
 

--- a/python/shotgun_model/data_handler_find.py
+++ b/python/shotgun_model/data_handler_find.py
@@ -179,7 +179,7 @@ class ShotgunFindDataHandler(ShotgunDataHandler):
         # If we don't already have a cache, we can continue on here by just populating
         # our new cache with the necessary data.
         if self._cache is None:
-            self._cache = new_cache
+            self.load_cache()
 
         if self._cache.size == 0:
             self._log_debug("In-memory cache is empty.")
@@ -296,16 +296,15 @@ class ShotgunFindDataHandler(ShotgunDataHandler):
             })
             num_deletes += 1
 
-        # Lastly, swap in the new cache if it's not already been done.
-        if self._cache is not new_cache:
-            self._cache = None
+        # Lastly, swap in the new cache
+        self._cache = None
 
-            # at this point, kick the gc to make sure the memory is freed up
-            # despite its cycles.
-            gc.collect()
+        # at this point, kick the gc to make sure the memory is freed up
+        # despite its cycles.
+        gc.collect()
 
-            # and set the new cache
-            self._cache = new_cache
+        # and set the new cache
+        self._cache = new_cache
 
         self._log_debug("Shotgun data (%d records) received and processed. " % len(sg_data))
         self._log_debug("    The new tree is %d records." % self._cache.size)

--- a/python/shotgun_model/data_handler_find.py
+++ b/python/shotgun_model/data_handler_find.py
@@ -174,8 +174,11 @@ class ShotgunFindDataHandler(ShotgunDataHandler):
         self._log_debug("Updating %s with %s shotgun records." % (self, len(sg_data)))
         self._log_debug("Hierarchy: %s" % self.__hierarchy)
 
+        new_cache = ShotgunDataHandlerCache()
+
         if self._cache is None:
-            raise ShotgunModelDataError("No data currently loaded in memory!")
+            # raise ShotgunModelDataError("No data currently loaded in memory!")
+            self._cache = new_cache
 
         if self._cache.size == 0:
             self._log_debug("In-memory cache is empty.")
@@ -193,8 +196,6 @@ class ShotgunFindDataHandler(ShotgunDataHandler):
         num_adds = 0
         num_deletes = 0
         num_modifications = 0
-
-        new_cache = ShotgunDataHandlerCache()
 
         # analyze the incoming shotgun data
         for sg_item in sg_data:
@@ -295,14 +296,15 @@ class ShotgunFindDataHandler(ShotgunDataHandler):
             num_deletes += 1
 
         # lastly swap the new for the old
-        self._cache = None
+        if self._cache is not new_cache:
+            self._cache = None
 
-        # at this point, kick the gc to make sure the memory is freed up
-        # despite its cycles.
-        gc.collect()
+            # at this point, kick the gc to make sure the memory is freed up
+            # despite its cycles.
+            gc.collect()
 
-        # and set the new cache
-        self._cache = new_cache
+            # and set the new cache
+            self._cache = new_cache
 
         self._log_debug("Shotgun data (%d records) received and processed. " % len(sg_data))
         self._log_debug("    The new tree is %d records." % self._cache.size)

--- a/python/shotgun_model/shotgun_query_model.py
+++ b/python/shotgun_model/shotgun_query_model.py
@@ -268,10 +268,18 @@ class ShotgunQueryModel(QtGui.QStandardItemModel):
         # Clear ourselves, preserving the data handler so that we can then
         # refresh. Clearing the model here ensures we don't end up with
         # duplicate items once the cache is cleared and repopulated.
-        self.clear(remove_data_handler=False)
-
-        # request a reload
-        self._refresh_data()
+        #
+        # Block all signals before we clear the model otherwise downstream
+        # proxy objects could cause crashes.
+        signals_blocked = self.blockSignals(True)
+        try:
+            # Clear all internal memory storage.
+            self.clear(remove_data_handler=False)
+            self._refresh_data()
+        finally:
+            # Reset the state of signal blocking.
+            self.blockSignals(signals_blocked)
+            self.modelReset.emit()
 
     def is_data_cached(self):
         """

--- a/python/shotgun_model/shotgun_query_model.py
+++ b/python/shotgun_model/shotgun_query_model.py
@@ -170,10 +170,14 @@ class ShotgunQueryModel(QtGui.QStandardItemModel):
     ############################################################################
     # public methods
 
-    def clear(self):
+    def clear(self, remove_data_handler=True):
         """
         Removes all items (including header items) from the model and
         sets the number of rows and columns to zero.
+
+        :param bool remove_data_handler: Whether to remove the reference to the
+            current data handler object. If False, the data handler will be
+            retained, which will allow the model to be repopulated.
         """
         # clear thumbnail download lookup so we don't process any more results:
         self.__thumb_map = {}
@@ -218,7 +222,7 @@ class ShotgunQueryModel(QtGui.QStandardItemModel):
             self.__do_depth_first_tree_deletion(self.invisibleRootItem())
 
             # unload the data backend
-            if self._data_handler:
+            if self._data_handler and remove_data_handler:
                 self._data_handler.unload_cache()
                 self._data_handler = None
 
@@ -260,6 +264,12 @@ class ShotgunQueryModel(QtGui.QStandardItemModel):
 
         # delete cache file
         self._data_handler.remove_cache()
+
+        # Clear ourselves, preserving the data handler so that we can then
+        # refresh. Clearing the model here ensures we don't end up with
+        # duplicate items once the cache is cleared and repopulated.
+        self.clear(remove_data_handler=False)
+
         # request a reload
         self._refresh_data()
 


### PR DESCRIPTION
During the hard refresh of a ShotgunQueryModel, the data handler's cache would be cleared out, and then the refresh process would request an update of the model's data. That call would fail, as it raised when no cache existed for the data handler. Instead, we now treat the missing cache kindly and just continue on with the update, which itself populates a fresh cache.