### PR TITLE
SG-4847: Supports executing commands with multiple entity ids as their input.

### DIFF
--- a/python/external_config/external_command.py
+++ b/python/external_config/external_command.py
@@ -297,7 +297,76 @@ class ExternalCommand(object):
         """
         return self._tooltip
 
-    def execute(self, pre_cache=False, entity_ids=None):
+    def execute(self, pre_cache=False):
+        """
+        Executes the external command in a separate process.
+
+        .. note:: The process will be launched in an synchronous way.
+            It is recommended that this command is executed in a worker thread::
+
+                # execute external command in a thread to not block
+                # main thread execution
+                worker = threading.Thread(target=action.execute)
+                # if the python environment shuts down, no need
+                # to wait for this thread
+                worker.daemon = True
+                # launch external process
+                worker.start()
+
+        :param bool pre_cache: If set to True, starting up the command
+            will also include a full caching of all necessary
+            dependencies for all contexts and engines. If set to False,
+            caching will only be carried as needed in order to run
+            the given command. This is an advanced setting that can be
+            useful to set to true when launching older engines which don't
+            launch via a bootstrap process. In that case, the engine simply
+            assumes that all necessary app dependencies already exists in
+            the bundle cache search path and without a pre-cache, apps
+            may not initialize correctly.
+        :raises: :class:`RuntimeError` on execution failure.
+        :returns: Output from execution session.
+        """
+        return self._execute(pre_cache)
+
+    def execute_on_multiple_entities(self, pre_cache=False, entity_ids=None):
+        """
+        Executes the external command in a separate process. This method
+        provides support for executing commands that support being run on
+        multiple entities as part of a single execution.
+
+        .. note:: The process will be launched in an synchronous way.
+            It is recommended that this command is executed in a worker thread::
+
+                # execute external command in a thread to not block
+                # main thread execution
+                worker = threading.Thread(target=action.execute)
+                # if the python environment shuts down, no need
+                # to wait for this thread
+                worker.daemon = True
+                # launch external process
+                worker.start()
+
+        :param bool pre_cache: If set to True, starting up the command
+            will also include a full caching of all necessary
+            dependencies for all contexts and engines. If set to False,
+            caching will only be carried as needed in order to run
+            the given command. This is an advanced setting that can be
+            useful to set to true when launching older engines which don't
+            launch via a bootstrap process. In that case, the engine simply
+            assumes that all necessary app dependencies already exists in
+            the bundle cache search path and without a pre-cache, apps
+            may not initialize correctly.
+        :param list entity_ids: A list of entity ids to use when executing
+            the command. This is only required when running legacy commands
+            that support being run on multiple entities at the same time. If
+            not given, a list will be built on the fly containing only the
+            entity id associated with this command.
+        :raises: :class:`RuntimeError` on execution failure.
+        :returns: Output from execution session.
+        """
+        return self._execute(pre_cache, entity_ids)
+
+    def _execute(self, pre_cache=False, entity_ids=None):
         """
         Executes the external command in a separate process.
 
@@ -355,8 +424,7 @@ class ExternalCommand(object):
                 plugin_id=self._plugin_id,
                 engine_name=self._engine_name,
                 entity_type=self._entity_type,
-                entity_id=self._entity_id,
-                entity_ids=entity_ids or [self._entity_id], # Legacy support for multi-entity commands
+                entity_ids=entity_ids or [self._entity_id],
                 bundle_cache_fallback_paths=self._bundle.engine.sgtk.bundle_cache_fallback_paths,
                 # the engine icon becomes the process icon
                 icon_path=self._bundle.engine.icon_256,

--- a/python/external_config/external_command.py
+++ b/python/external_config/external_command.py
@@ -334,18 +334,6 @@ class ExternalCommand(object):
         provides support for executing commands that support being run on
         multiple entities as part of a single execution.
 
-        .. note:: The process will be launched in an synchronous way.
-            It is recommended that this command is executed in a worker thread::
-
-                # execute external command in a thread to not block
-                # main thread execution
-                worker = threading.Thread(target=action.execute)
-                # if the python environment shuts down, no need
-                # to wait for this thread
-                worker.daemon = True
-                # launch external process
-                worker.start()
-
         :param bool pre_cache: If set to True, starting up the command
             will also include a full caching of all necessary
             dependencies for all contexts and engines. If set to False,
@@ -369,18 +357,6 @@ class ExternalCommand(object):
     def _execute(self, pre_cache=False, entity_ids=None):
         """
         Executes the external command in a separate process.
-
-        .. note:: The process will be launched in an synchronous way.
-            It is recommended that this command is executed in a worker thread::
-
-                # execute external command in a thread to not block
-                # main thread execution
-                worker = threading.Thread(target=action.execute)
-                # if the python environment shuts down, no need
-                # to wait for this thread
-                worker.daemon = True
-                # launch external process
-                worker.start()
 
         :param bool pre_cache: If set to True, starting up the command
             will also include a full caching of all necessary

--- a/python/external_config/external_command.py
+++ b/python/external_config/external_command.py
@@ -297,7 +297,7 @@ class ExternalCommand(object):
         """
         return self._tooltip
 
-    def execute(self, pre_cache=False):
+    def execute(self, pre_cache=False, entity_ids=None):
         """
         Executes the external command in a separate process.
 
@@ -323,6 +323,11 @@ class ExternalCommand(object):
             assumes that all necessary app dependencies already exists in
             the bundle cache search path and without a pre-cache, apps
             may not initialize correctly.
+        :param list entity_ids: A list of entity ids to use when executing
+            the command. This is only required when running legacy commands
+            that support being run on multiple entities at the same time. If
+            not given, a list will be built on the fly containing only the
+            entity id associated with this command.
         :raises: :class:`RuntimeError` on execution failure.
         :returns: Output from execution session.
         """
@@ -351,6 +356,7 @@ class ExternalCommand(object):
                 engine_name=self._engine_name,
                 entity_type=self._entity_type,
                 entity_id=self._entity_id,
+                entity_ids=entity_ids or [self._entity_id], # Legacy support for multi-entity commands
                 bundle_cache_fallback_paths=self._bundle.engine.sgtk.bundle_cache_fallback_paths,
                 # the engine icon becomes the process icon
                 icon_path=self._bundle.engine.icon_256,

--- a/python/external_config/scripts/external_runner.py
+++ b/python/external_config/scripts/external_runner.py
@@ -420,7 +420,7 @@ def main():
             engine.execute_old_style_command(
                 callback_name,
                 arg_data["entity_type"],
-                [arg_data["entity_id"]]
+                arg_data["entity_ids"],
             )
         else:
             # standard route - just run the callback

--- a/python/external_config/scripts/external_runner.py
+++ b/python/external_config/scripts/external_runner.py
@@ -350,7 +350,7 @@ def main():
                 arg_data["plugin_id"],
                 arg_data["engine_name"],
                 arg_data["entity_type"],
-                arg_data["entity_id"],
+                arg_data["entity_ids"][0],
                 arg_data["bundle_cache_fallback_paths"],
                 arg_data.get("pre_cache") or False,
             )
@@ -380,7 +380,7 @@ def main():
         cache_commands(
             engine,
             arg_data["entity_type"],
-            arg_data["entity_id"],
+            arg_data["entity_ids"][0],
             arg_data["cache_path"]
         )
 
@@ -391,7 +391,7 @@ def main():
             arg_data["plugin_id"],
             arg_data["engine_name"],
             arg_data["entity_type"],
-            arg_data["entity_id"],
+            arg_data["entity_ids"][0],
             arg_data["bundle_cache_fallback_paths"],
             False,
         )

--- a/python/external_config/scripts/external_runner.py
+++ b/python/external_config/scripts/external_runner.py
@@ -350,7 +350,7 @@ def main():
                 arg_data["plugin_id"],
                 arg_data["engine_name"],
                 arg_data["entity_type"],
-                arg_data["entity_ids"][0],
+                arg_data["entity_id"],
                 arg_data["bundle_cache_fallback_paths"],
                 arg_data.get("pre_cache") or False,
             )
@@ -380,7 +380,7 @@ def main():
         cache_commands(
             engine,
             arg_data["entity_type"],
-            arg_data["entity_ids"][0],
+            arg_data["entity_id"],
             arg_data["cache_path"]
         )
 


### PR DESCRIPTION
Allows a list of entity ids to be passed in when executing a command. This list is then passed on to any call of `engine.execute_old_style_command` to allow for support of legacy commands that can run on multiple entities at the same time.