### PR TITLE
SG-7486: Reimplements how inaccessible configurations are communicated.

### DIFF
--- a/python/external_config/config/config_base.py
+++ b/python/external_config/config/config_base.py
@@ -230,17 +230,6 @@ class ExternalConfiguration(QtCore.QObject):
         :raises: RuntimeError if this configuration's status does not allow for
             commands requests.
         """
-        # Make sure that we're a valid configuration. If we aren't, then we
-        # won't be able to successfully request commands. That being the case,
-        # we can raise here.
-        if not self.is_valid:
-            logger.debug("Commands were requested from an invalid config: %r", self)
-            raise RuntimeError(
-                "Configuration (%s) has a status that marks it as invalid, "
-                "and therefore inaccessible. It is not possible to request "
-                "commands from this configuration as a result." % self
-            )
-
         logger.debug("Requested commands for %s: %s %s %s" % (self, entity_type, entity_id, link_entity_type))
 
         # run entire command check and generation in worker

--- a/python/external_config/config/config_fallback.py
+++ b/python/external_config/config/config_fallback.py
@@ -34,6 +34,7 @@ class FallbackExternalConfiguration(ExternalConfiguration):
             interpreter,
             software_hash,
             pipeline_config_uri,
+            status=ExternalConfiguration.CONFIGURATION_READY
     ):
         """
         .. note:: This class is constructed by :class:`ExternalConfigurationLoader`.
@@ -56,7 +57,8 @@ class FallbackExternalConfiguration(ExternalConfiguration):
             engine_name,
             interpreter,
             software_hash,
-            pipeline_config_uri
+            pipeline_config_uri,
+            status
         )
 
         # is our config uri tracking the latest version?

--- a/python/external_config/config/config_invalid.py
+++ b/python/external_config/config/config_invalid.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2018 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import sgtk
+
+from .config_base import ExternalConfiguration
+
+logger = sgtk.platform.get_logger(__name__)
+
+
+class InvalidExternalConfiguration(ExternalConfiguration):
+    """
+    Represents an external configuration that is invalid, and cannot be used
+    as a source for requesting commands.
+    """
+
+    def __init__(
+            self,
+            parent,
+            bg_task_manager,
+            plugin_id,
+            engine_name,
+            interpreter,
+            software_hash,
+            pipeline_config_id,
+            status=ExternalConfiguration.CONFIGURATION_INACCESSIBLE
+    ):
+        """
+        .. note:: This class is constructed by :class:`ExternalConfigurationLoader`.
+            Do not construct objects by hand.
+
+        :param parent: QT parent object.
+        :type parent: :class:`~PySide.QtGui.QObject`
+        :param bg_task_manager: Background task manager to use for any asynchronous work.
+        :type bg_task_manager: :class:`~task_manager.BackgroundTaskManager`
+        :param str plugin_id: Associated bootstrap plugin id
+        :param str engine_name: Associated engine name
+        :param str interpreter: Associated Python interpreter
+        :param str software_hash: Hash representing the state of the Shotgun software entity
+        :param id pipeline_config_id: Pipeline Configuration id
+        :param int status: The status of the configuration as an enum defined by
+            :class:`ExternalConfiguration`.
+        """
+        super(InvalidExternalConfiguration, self).__init__(
+            parent=parent,
+            bg_task_manager=bg_task_manager,
+            plugin_id=plugin_id,
+            engine_name=engine_name,
+            interpreter=interpreter,
+            software_hash=software_hash,
+            pipeline_config_uri=None,
+            status=status
+        )
+
+        self._pipeline_configuration_id = pipeline_config_id
+
+    def __repr__(self):
+        """
+        String representation
+        """
+        return "<InvalidExternalConfiguration id %d, status %d>" % (
+            self._pipeline_configuration_id,
+            self.status,
+        )
+
+    @property
+    def is_valid(self):
+        """
+        Returns ``False``, which indicates that this is an invalid configuration
+        and is inaccessible for some reason.
+        """
+        return False
+
+    @property
+    def pipeline_configuration_id(self):
+        """
+        The associated PipelineConfiguration entity id.
+        """
+        return self._pipeline_configuration_id
+
+    def request_commands(self, *args, **kwargs):
+        """
+        This implementation raises an exception, as it's not possible to
+        request commands from an invalid configuration.
+
+        :raises: RuntimeError
+        """
+        logger.debug("Commands were requested from an invalid configuration: %r", self)
+        raise RuntimeError("It is not possible to request commands from an invalid configuration.")
+
+
+

--- a/python/external_config/config/config_live.py
+++ b/python/external_config/config/config_live.py
@@ -40,6 +40,7 @@ class LiveExternalConfiguration(ExternalConfiguration):
             pipeline_config_name,
             pipeline_config_uri,
             pipeline_config_folder,
+            status=ExternalConfiguration.CONFIGURATION_READY
     ):
         """
         .. note:: This class is constructed by :class:`ExternalConfigurationLoader`.
@@ -65,7 +66,8 @@ class LiveExternalConfiguration(ExternalConfiguration):
             engine_name,
             interpreter,
             software_hash,
-            pipeline_config_uri
+            pipeline_config_uri,
+            status
         )
 
         self._pipeline_configuration_id = pipeline_config_id

--- a/python/external_config/config/config_remote.py
+++ b/python/external_config/config/config_remote.py
@@ -33,6 +33,7 @@ class RemoteExternalConfiguration(ExternalConfiguration):
             pipeline_config_id,
             pipeline_config_name,
             pipeline_config_uri,
+            status=ExternalConfiguration.CONFIGURATION_READY
     ):
         """
         .. note:: This class is constructed by :class:`ExternalConfigurationLoader`.
@@ -57,7 +58,8 @@ class RemoteExternalConfiguration(ExternalConfiguration):
             engine_name,
             interpreter,
             software_hash,
-            pipeline_config_uri
+            pipeline_config_uri,
+            status
         )
 
         self._pipeline_configuration_id = pipeline_config_id

--- a/python/external_config/errors.py
+++ b/python/external_config/errors.py
@@ -14,11 +14,3 @@ class ExternalConfigParseError(RuntimeError):
     Indicates that the given serialized data is not usable
     """
     pass
-
-
-class ExternalConfigNotAccessibleError(RuntimeError):
-    """
-    Indicates that a configuration is not accessible
-    """
-    pass
-

--- a/python/external_config/external_config_loader.py
+++ b/python/external_config/external_config_loader.py
@@ -12,7 +12,7 @@ import sgtk
 from sgtk.platform.qt import QtCore, QtGui
 from .configuration_state import ConfigurationState
 from . import file_cache
-from .errors import ExternalConfigNotAccessibleError, ExternalConfigParseError
+from .errors import ExternalConfigParseError
 from . import config
 
 logger = sgtk.platform.get_logger(__name__)
@@ -24,7 +24,7 @@ class ExternalConfigurationLoader(QtCore.QObject):
 
     **Signal Interface**
 
-    :signal configurations_loaded(project_id, configs, error): Gets emitted configurations
+    :signal configurations_loaded(project_id, configs): Gets emitted configurations
         have been loaded for the given project. The parameters passed is the
         project id and a list of :class:`ExternalConfiguration` instances. If errors
         occurred while loading configurations, the error property will be set to a tuple
@@ -41,7 +41,7 @@ class ExternalConfigurationLoader(QtCore.QObject):
 
     # signal emitted to indicate that an update has been detected
     # to the pipeline configurations for a project
-    configurations_loaded = QtCore.Signal(int, list, tuple)  # project_id, list of configs, error
+    configurations_loaded = QtCore.Signal(int, list)  # project_id, list of configs
 
     # signal to indicate that change to the configurations have been detected.
     configurations_changed = QtCore.Signal()
@@ -198,7 +198,7 @@ class ExternalConfigurationLoader(QtCore.QObject):
                 logger.debug("Detected and deleted out of date cache.")
 
             else:
-                self.configurations_loaded.emit(project_id, config_objects, ())
+                self.configurations_loaded.emit(project_id, config_objects)
                 config_data_emitted = True
 
         if not config_data_emitted:
@@ -254,24 +254,23 @@ class ExternalConfigurationLoader(QtCore.QObject):
         # check that the configs are complete. If not, issue warnings
         config_objects = []
         for config_dict in config_dicts:
-            try:
-                config_object = config.create_from_pipeline_configuration_data(
-                    parent=self,
-                    bg_task_manager=self._bg_task_manager,
-                    config_loader=self,
-                    configuration_data=config_dict
-                )
-                config_objects.append(config_object)
-            except ExternalConfigNotAccessibleError as e:
-                logger.error("%s Configuration will not be loaded." % e)
-                raise
+            config_object = config.create_from_pipeline_configuration_data(
+                parent=self,
+                bg_task_manager=self._bg_task_manager,
+                config_loader=self,
+                configuration_data=config_dict
+            )
+            config_objects.append(config_object)
+
+            if not config_object.is_valid:
+                logger.debug("Configuration (%r) was found, but is invalid.", config_object)
 
         # if no custom pipeline configs were found, we use the base config
         # note: because the base config can change over time, we make sure
         # to include it as an ingredient in the hash key below.
-        if not config_objects:
+        if not config_dicts:
             logger.debug(
-                "No usable configurations were found. Using the fallback configuration."
+                "No configurations were found. Using the fallback configuration."
             )
             config_objects.append(
                 config.create_fallback_configuration(
@@ -307,7 +306,7 @@ class ExternalConfigurationLoader(QtCore.QObject):
             "Got configuration objects for project %s: %s" % (project_id, config_objects)
         )
 
-        self.configurations_loaded.emit(project_id, config_objects, ())
+        self.configurations_loaded.emit(project_id, config_objects)
 
     def _task_failed(self, unique_id, group, message, traceback_str):
         """
@@ -327,4 +326,4 @@ class ExternalConfigurationLoader(QtCore.QObject):
         logger.error("Could not determine project configurations: %s" % message)
 
         # emit an empty list of configurations
-        self.configurations_loaded.emit(project_id, [], (message, traceback_str))
+        self.configurations_loaded.emit(project_id, [])

--- a/python/external_config/scripts/external_runner.py
+++ b/python/external_config/scripts/external_runner.py
@@ -341,6 +341,7 @@ def main():
     )
 
     action = arg_data["action"]
+    engine = None
 
     if action == "cache_actions":
         try:


### PR DESCRIPTION
This is a reimplementation of how we track inaccessible configurations found when getting configs, and how those are reported to the caller. Instead of passing error messages to the caller, we now track invalid configurations as an "invalid" external configuration object with an enum status that can be used to know WHY the configuration is invalid.

Currently, we only have enums for CONFIGURATION_READY and CONFIGURATION_INACCESSIBLE, but this can be expanded in the future if required.