### PR TITLE
SG-3025: Closes the external process when the command finishes if no widgets are visible.

### DIFF
--- a/python/external_config/scripts/external_runner.py
+++ b/python/external_config/scripts/external_runner.py
@@ -131,8 +131,13 @@ class QtTaskRunner(qt_importer.QtCore.QObject):
         finally:
             # broadcast that we have finished this command
             qt_app = qt_importer.QtCore.QCoreApplication.instance()
+
             if len(qt_app.topLevelWidgets()) == 0:
                 # no windows opened. we are done!
+                self.completed.emit()
+            elif not [w for w in qt_app.topLevelWidgets() if w.isVisible()]:
+                # There are windows, but they're all hidden, which means we should
+                # be safe to shut down.
                 self.completed.emit()
 
 


### PR DESCRIPTION
This is in addition to the existing check to see if any top-level widgets exist. We've run into cases where the widgets still exist in memory post execution, but are not visible. In that situation, we should go ahead and shut down the QApplication and exit the external process normally.