### PR TITLE
SG-7531: Ensures that PYTHONPATH includes everything in sys.path

### DIFF
--- a/python/external_config/config/config_base.py
+++ b/python/external_config/config/config_base.py
@@ -439,7 +439,10 @@ class ExternalConfiguration(QtCore.QObject):
             logger.debug("External caching complete. Output: %s" % output)
         finally:
             # Leave PYTHONPATH the way we found it.
-            os.environ["PYTHONPATH"] = current_pypath
+            if current_pypath is None:
+                del os.environ["PYTHONPATH"]
+            else:
+                os.environ["PYTHONPATH"] = current_pypath
 
             # clean up temp file
             sgtk.util.filesystem.safe_delete_file(args_file)


### PR DESCRIPTION
Before we spawn a subprocess to run an external command, we now set PYTHONPATH to include everything in sys.path. This ensures that we're importing Python modules predictably from subprocesses.