### PR TITLE
SG-7531: QA fixes for PYTHONPATH handling when spawning subprocesses.

### DIFF
--- a/python/external_config/config/config_base.py
+++ b/python/external_config/config/config_base.py
@@ -395,6 +395,11 @@ class ExternalConfiguration(QtCore.QObject):
             )
         )
 
+        # We might have paths in sys.path that aren't in PYTHONPATH. We'll make
+        # sure that we prepend our current pathing to that prior to spawning any
+        # subprocesses.
+        current_pypath = os.environ.get("PYTHONPATH")
+
         args_file = create_parameter_file(
             dict(
                 action="cache_actions",
@@ -409,6 +414,7 @@ class ExternalConfiguration(QtCore.QObject):
                 # the engine icon becomes the process icon
                 icon_path=self._bundle.engine.icon_256,
                 pre_cache=pre_cache,
+                pythonpath=current_pypath,
             )
         )
 
@@ -426,14 +432,8 @@ class ExternalConfiguration(QtCore.QObject):
         # to prompt the user to re-authenticate.
         sgtk.get_authenticated_user().refresh_credentials()
 
-        # We might have paths in sys.path that aren't in PYTHONPATH. We'll make
-        # sure that we prepend our current pathing to that prior to spawning any
-        # subprocesses.
-        current_pypath = os.environ.get("PYTHONPATH")
-
-        sgtk.util.prepend_path_to_env_var("PYTHONPATH", sys.path[0])
-        # for path in sys.path:
-            # sgtk.util.prepend_path_to_env_var("PYTHONPATH", path)
+        for path in sys.path:
+            sgtk.util.prepend_path_to_env_var("PYTHONPATH", path)
 
         try:
             output = subprocess_check_output(args)

--- a/python/external_config/config/config_base.py
+++ b/python/external_config/config/config_base.py
@@ -431,8 +431,9 @@ class ExternalConfiguration(QtCore.QObject):
         # subprocesses.
         current_pypath = os.environ.get("PYTHONPATH")
 
-        for path in sys.path:
-            sgtk.util.prepend_path_to_env_var("PYTHONPATH", path)
+        sgtk.util.prepend_path_to_env_var("PYTHONPATH", sys.path[0])
+        # for path in sys.path:
+            # sgtk.util.prepend_path_to_env_var("PYTHONPATH", path)
 
         try:
             output = subprocess_check_output(args)

--- a/python/external_config/config/config_base.py
+++ b/python/external_config/config/config_base.py
@@ -436,7 +436,14 @@ class ExternalConfiguration(QtCore.QObject):
             sgtk.util.prepend_path_to_env_var("PYTHONPATH", path)
 
         try:
-            output = subprocess_check_output(args)
+            # Note: passing a copy of the environment in resolves some odd behavior with
+            # the environment of processes spawned from the external_runner. This caused
+            # some very bad behavior where it looked like PYTHONPATH was inherited from
+            # this top-level environment rather than what is being set in external_runner
+            # prior to launch. This is less critical here when caching configs, because
+            # we're unlikely to spawn additional processes from the external_runner, but
+            # just to cover our backsides, this is safest.
+            output = subprocess_check_output(args, env=os.environ.copy())
             logger.debug("External caching complete. Output: %s" % output)
         finally:
             # Leave PYTHONPATH the way we found it.

--- a/python/external_config/external_command.py
+++ b/python/external_config/external_command.py
@@ -394,6 +394,12 @@ class ExternalCommand(object):
         # We might have paths in sys.path that aren't in PYTHONPATH. We'll make
         # sure that we prepend our current pathing to that prior to spawning any
         # subprocesses.
+        #
+        # One additional step that we'll take is to send the original PYTHONPATH
+        # to the external_runner we spawn, and ask it to set PYTHONPATH to that
+        # value before it does its work. That means we have everything required
+        # for external_runner when we run it, but we'll keep the environment
+        # clean for any process that it might spawn, like when launching a DCC.
         current_pypath = os.environ.get("PYTHONPATH")
 
         # pass arguments via a pickled temp file.

--- a/python/external_config/external_command.py
+++ b/python/external_config/external_command.py
@@ -422,8 +422,10 @@ class ExternalCommand(object):
         # subprocesses.
         current_pypath = os.environ.get("PYTHONPATH")
 
-        for path in sys.path:
-            sgtk.util.prepend_path_to_env_var("PYTHONPATH", path)
+        # for path in sys.path:
+        sgtk.util.prepend_path_to_env_var("PYTHONPATH", sys.path[0])
+            # logger.warning("******************************************")
+            # logger.warning(os.environ["PYTHONPATH"])
 
         try:
             output = subprocess_check_output(args)

--- a/python/external_config/external_command.py
+++ b/python/external_config/external_command.py
@@ -434,7 +434,12 @@ class ExternalCommand(object):
             sgtk.util.prepend_path_to_env_var("PYTHONPATH", path)
 
         try:
-            output = subprocess_check_output(args)
+            # Note: passing a copy of the environment in resolves some odd behavior with
+            # the environment of processes spawned from the external_runner. This caused
+            # some very bad behavior where it looked like PYTHONPATH was inherited from
+            # this top-level environment rather than what is being set in external_runner
+            # prior to launch.
+            output = subprocess_check_output(args, env=os.environ.copy())
             logger.debug("External execution complete. Output: %s" % output)
         except SubprocessCalledProcessError as e:
             # caching failed!

--- a/python/external_config/scripts/external_runner.py
+++ b/python/external_config/scripts/external_runner.py
@@ -345,7 +345,7 @@ def main():
     # external_runner script to run properly, but that would cause problems
     # when a process is spawned from this script, like when launching a DCC.
     if "pythonpath" in arg_data:
-        if arg_data["pythonpath"] is None:
+        if arg_data["pythonpath"] is None and "PYTHONPATH" in os.environ:
             del os.environ["PYTHONPATH"]
         else:
             os.environ["PYTHONPATH"] = arg_data["pythonpath"]

--- a/python/external_config/scripts/external_runner.py
+++ b/python/external_config/scripts/external_runner.py
@@ -340,6 +340,12 @@ def main():
     with open(arg_data_file, "rb") as fh:
         arg_data = cPickle.load(fh)
 
+    # Set the PYTHONPATH requested.
+    if arg_data["pythonpath"] is None:
+        del os.environ["PYTHONPATH"]
+    else:
+        os.environ["PYTHONPATH"] = arg_data["pythonpath"]
+
     # Add application icon
     qt_application.setWindowIcon(
         qt_importer.QtGui.QIcon(arg_data["icon_path"])

--- a/python/external_config/scripts/external_runner.py
+++ b/python/external_config/scripts/external_runner.py
@@ -340,11 +340,15 @@ def main():
     with open(arg_data_file, "rb") as fh:
         arg_data = cPickle.load(fh)
 
-    # Set the PYTHONPATH requested.
-    if arg_data["pythonpath"] is None:
-        del os.environ["PYTHONPATH"]
-    else:
-        os.environ["PYTHONPATH"] = arg_data["pythonpath"]
+    # Set the PYTHONPATH if requested. This is an important step, as our parent
+    # process might have polluted PYTHONPATH with data required for this
+    # external_runner script to run properly, but that would cause problems
+    # when a process is spawned from this script, like when launching a DCC.
+    if "pythonpath" in arg_data:
+        if arg_data["pythonpath"] is None:
+            del os.environ["PYTHONPATH"]
+        else:
+            os.environ["PYTHONPATH"] = arg_data["pythonpath"]
 
     # Add application icon
     qt_application.setWindowIcon(


### PR DESCRIPTION
This addresses an issue where the PYTHONPATH changes defined in external_config prior to spawning external_runner subprocesses would leak into DCCs launched from the external_runner. This caused some compatibility issues with Python libraries, as we overrode what shipped with the DCC with what SGC has bundled. That was bad, obviously, so we're now cleaning up after ourselves once the external_runner process is running, but before we spawn any processes from it.