### PR TITLE
This is a workaround for https://jira.autodesk.com/browse/SHOT-2806

### DIFF
--- a/python/shotgun_model/util.py
+++ b/python/shotgun_model/util.py
@@ -149,10 +149,7 @@ def sanitize_qt(val):
         return new_val
 
     elif isinstance(val, long):
-        try:
-            val = int(val)
-        except ValueError:
-            pass
+        val = int(val)
         return val
     else:
         return val        

--- a/python/shotgun_model/util.py
+++ b/python/shotgun_model/util.py
@@ -148,15 +148,10 @@ def sanitize_qt(val):
             new_val[safe_key] = safe_val
         return new_val
 
-    """
-    This is a workaround for the JIRA ticket 
-    https://jira.autodesk.com/browse/SHOT-2806
-    QT Version: 5.9.5
-    PySide Version: 5.9.0a1
-    VRED version: 2020
-
-    The value should be `int` but it is `long`. 
-    """
+    # QT Version: 5.9.5
+    # PySide Version: 5.9.0a1
+    # VRED version: 2020
+    # The value should be `int` but it is `long`.
     elif isinstance(val, long):
         val = int(val)
         return val

--- a/python/shotgun_model/util.py
+++ b/python/shotgun_model/util.py
@@ -148,6 +148,12 @@ def sanitize_qt(val):
             new_val[safe_key] = safe_val
         return new_val
 
+    elif isinstance(val, long):
+        try:
+            val = int(val)
+        except ValueError:
+            pass
+        return val
     else:
         return val        
 

--- a/python/shotgun_model/util.py
+++ b/python/shotgun_model/util.py
@@ -148,6 +148,15 @@ def sanitize_qt(val):
             new_val[safe_key] = safe_val
         return new_val
 
+    """
+    This is a workaround for the JIRA ticket 
+    https://jira.autodesk.com/browse/SHOT-2806
+    QT Version: 5.9.5
+    PySide Version: 5.9.0a1
+    VRED version: 2020
+
+    The value should be `int` but it is `long`. 
+    """
     elif isinstance(val, long):
         val = int(val)
         return val

--- a/python/shotgun_model/util.py
+++ b/python/shotgun_model/util.py
@@ -150,7 +150,6 @@ def sanitize_qt(val):
 
     # QT Version: 5.9.5
     # PySide Version: 5.9.0a1
-    # VRED version: 2020
     # The value should be `int` but it is `long`.
     elif isinstance(val, long):
         val = int(val)


### PR DESCRIPTION
Toolkit expects the following code

from PySide2 import QtGui
i = QtGui.QStandardItem()
i.setData(1, 1)
print i.data(1)._class_

to print out <type 'int'>, but in the case of VRed it gives back <type 'long'>.