### PR TITLE
Fixes error when six is not installed

### DIFF
--- a/python/shotgun_model/util.py
+++ b/python/shotgun_model/util.py
@@ -10,7 +10,6 @@
 
 from tank.platform.qt import QtCore
 
-import six.moves.urllib.parse
 from tank_vendor.shotgun_api3.lib import six
 from tank_vendor.shotgun_api3.lib.six.moves import range
 


### PR DESCRIPTION
Removes a six import that relied on six being installed (rather than using the copy shipped with python-api.)  Since six was already imported below, we can just drop this import.