### PR TITLE
VMR-2799: Adds a getter/setter for interpreter paths in external commands

### DIFF
--- a/python/external_config/config/config_base.py
+++ b/python/external_config/config/config_base.py
@@ -315,7 +315,11 @@ class ExternalConfiguration(QtCore.QObject):
         else:
             cached_data = file_cache.load_cache(cache_hash)
 
-        if cached_data is None or not ExternalCommand.is_compatible(cached_data):
+        if (
+            cached_data is None
+            or not ExternalCommand.is_compatible(cached_data)
+            or not ExternalCommand.is_valid_data(cached_data)
+        ):
             logger.debug("Begin caching commands")
 
             # if entity_id is None, we need to figure out an actual entity id

--- a/python/external_config/config/config_base.py
+++ b/python/external_config/config/config_base.py
@@ -134,6 +134,15 @@ class ExternalConfiguration(QtCore.QObject):
         """
         return self._interpreter
 
+    @interpreter.setter
+    def interpreter(self, interpreter):
+        """
+        Sets the configuration's Python interpreter.
+
+        :param str interpreter: The Python interpreter path.
+        """
+        self._interpreter = interpreter
+
     @property
     def software_hash(self):
         """

--- a/python/external_config/external_command.py
+++ b/python/external_config/external_command.py
@@ -42,6 +42,32 @@ class ExternalCommand(object):
             return False
 
     @classmethod
+    def is_valid_data(cls, data):
+        """
+        Tests whether key components of the data contained in the cache are still
+        valid. This helps protect against file paths that might have been cached
+        that no longer exist.
+
+        :param dict data: Serialized data
+        :returns: True if the given data passes validation, False if not.
+        """
+        # We're only testing icon paths here just because that's the problem we
+        # have right now in SG Create, but it's entirely possible (and maybe
+        # advisable) to check other things that are file/directory paths on
+        # disk that might no longer exist.
+        icon_passes = True
+
+        for command in data.get("commands", []):
+            icon = command.get("icon")
+            if icon and not os.path.exists(icon):
+                logger.debug("Icon path in cached data is invalid: %s", icon)
+                logger.debug("External commands will be recached.")
+                icon_passes = False
+                break
+
+        return icon_passes
+
+    @classmethod
     def create(cls, external_configuration, data, entity_id):
         """
         Creates a new :class:`ExternalCommand` instance based on the
@@ -138,7 +164,23 @@ class ExternalCommand(object):
         self._pipeline_config_name = pipeline_config_name
         self._sg_deny_permissions = sg_deny_permissions
         self._sg_supports_multiple_selection = sg_supports_multiple_selection
-        self._icon = icon
+
+        # We need to check the validity of the icon path provided and
+        # not keep it if it doesn't exist. This will prevent an infinite
+        # re-cache loop when commands are requested from an external config
+        # object. That object's routine is to validate the contents of
+        # cached data before using it, and if an icon referenced in the
+        # cache doesn't exist (but is not None) then the cache is dumped.
+        if icon and os.path.exists(icon):
+            # Good icon path provided.
+            self._icon = icon
+        elif icon:
+            # Non-existent icon provided, which we will not record.
+            logger.warning("Icon provided does not exist and will not be used: %s", icon)
+            self._icon = None
+        else:
+            # No icon provided.
+            self._icon = None
 
     def __repr__(self):
         """

--- a/python/external_config/external_command.py
+++ b/python/external_config/external_command.py
@@ -307,6 +307,23 @@ class ExternalCommand(object):
         """
         return self._tooltip
 
+    @property
+    def interpreter(self):
+        """
+        The Python interpreter path to use when executing the command.
+        """
+        return self._interpreter
+
+    @interpreter.setter
+    def interpreter(self, interpreter):
+        """
+        Set the command's Python interpreter path.
+
+        :param str interpreter: The new interpreter path to use when executing the
+            command.
+        """
+        self._interpreter = interpreter
+
     def execute(self, pre_cache=False):
         """
         Executes the external command in a separate process.

--- a/tests/external_config/test_external_command.py
+++ b/tests/external_config/test_external_command.py
@@ -8,6 +8,9 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+import os
+import contextlib
+
 from mock import patch
 
 from sgtk.util import process  # noqa
@@ -27,6 +30,10 @@ class TestExternalCommand(ExternalConfigBase):
         """
         super(TestExternalCommand, self).setUp()
 
+        self._icon_path = (
+            "/Applications/Autodesk/maya2017/Maya.app/Contents/icons/mayaico.png"
+        )
+
         # example taken from a working 'Shotgun Create / tk-desktop2' setup
         self._data = {
             "sg_supports_multiple_selection": None,
@@ -39,7 +46,7 @@ class TestExternalCommand(ExternalConfigBase):
             "group": "Maya",
             "type": None,
             "group_default": False,
-            "icon": "/Applications/Autodesk/maya2017/Maya.app/Contents/icons/mayaico.png",
+            "icon": self._icon_path,
         }
 
         # The ExternalCommand create method expects the following field which I couldn't figure out origin
@@ -55,10 +62,30 @@ class TestExternalCommand(ExternalConfigBase):
         self.external_config_loader.pipeline_configuration_id = None
         self.external_config_loader.pipeline_configuration_name = None
 
-        # Creating the external command object
-        self._external_command = self.external_config.ExternalCommand.create(
-            self.external_config_loader, self.ec_data, "Task"
-        )
+        # Creating a command can invalidate the icon if it's missing. We don't want
+        # that here.
+        with self._pretend_icon_exists():
+            # Creating the external command object
+            self._external_command = self.external_config.ExternalCommand.create(
+                self.external_config_loader, self.ec_data, "Task"
+            )
+
+    @contextlib.contextmanager
+    def _pretend_icon_exists(self):
+        """
+        Mocks the os.path.exists method so that the icon is found
+        on disk during the test even tough it doesn't actually exist.
+        """
+        original_os_path_exists = os.path.exists
+
+        def ico_exists(path):
+            if path == self._icon_path:
+                return True
+            else:
+                return original_os_path_exists(path)
+
+        with patch("os.path.exists", side_effect=ico_exists):
+            yield
 
     @property
     def ec_data(self):
@@ -109,8 +136,11 @@ class TestExternalCommand(ExternalConfigBase):
         # Serialize our test base object
         a_pickle = self.ec.serialize()
 
-        # Create a new object from the serialize data
-        ec2 = self.external_config.ExternalCommand.deserialize(a_pickle)
+        # Unserializing a command creates it, which may invalidate the icon
+        # if missing. We don't want that here.
+        with self._pretend_icon_exists():
+            # Create a new object from the serialize data
+            ec2 = self.external_config.ExternalCommand.deserialize(a_pickle)
 
         # Test that new object similarity with original one
         # Unfortunately the ExternalCommand object is not implementing a custom equal method
@@ -134,6 +164,15 @@ class TestExternalCommand(ExternalConfigBase):
         )
         self.assertEquals(self.ec.tooltip, ec2.tooltip)
         self.assertEquals(repr(self.ec), repr(ec2))
+
+    def test_detect_missing_icon(self):
+        """
+        Ensure a missing icon is detected and wiped from the command.
+        """
+        self._external_command = self.external_config.ExternalCommand.create(
+            self.external_config_loader, self.ec_data, "Task"
+        )
+        self.assertIsNone(self.ec.icon)
 
     @patch("sgtk.util.process.subprocess_check_output")
     @patch("sgtk.util.filesystem.safe_delete_file")


### PR DESCRIPTION
This will allow for tk-desktop2 (and other integrations, where necessary) to change the interpreter path associated with a command after it's been loaded from the cache. This is useful in situations where the interpreter path might have changed after the commands were cached to disk, such as in SG Create where the path changes during an update of the host application.