### PR TITLE
SG-13276: Fixed task priority sorting

### DIFF
--- a/python/task_manager/background_task_manager.py
+++ b/python/task_manager/background_task_manager.py
@@ -23,7 +23,7 @@ from .results_poller import ResultsDispatcher
 # Set to True to enable extensive debug logging.
 # Useful for debugging concurrency issues.
 # Do not release with this setting set to True!
-ENABLE_DETAILED_DEBUG = True
+ENABLE_DETAILED_DEBUG = False
 
 
 class BackgroundTaskManager(QtCore.QObject):

--- a/python/task_manager/background_task_manager.py
+++ b/python/task_manager/background_task_manager.py
@@ -210,7 +210,9 @@ class BackgroundTaskManager(QtCore.QObject):
         new_task = BackgroundTask(task_id, cbl, group, priority, task_args, task_kwargs)
 
         # add the task to the pending queue:
-        self._pending_tasks_by_priority.setdefault(priority, []).append(new_task)
+        # If priority is None, then use 0 so when we sort we're only comparing integers.
+        # Python 3 raises an error when comparing int with NoneType.
+        self._pending_tasks_by_priority.setdefault(priority or 0, []).append(new_task)
 
         # add tasks to various look-ups:
         self._tasks_by_id[new_task.uid] = new_task
@@ -421,7 +423,7 @@ class BackgroundTaskManager(QtCore.QObject):
 
         # figure out next task to start from the priority queue:
         task_to_process = None
-        priorities = sorted(self._pending_tasks_by_priority.keys(), reverse=True)
+        priorities = sorted(self._pending_tasks_by_priority, reverse=True)
         for priority in priorities:
             # iterate through the tasks and make sure we aren't waiting on the
             # completion of any upstream tasks:

--- a/python/task_manager/background_task_manager.py
+++ b/python/task_manager/background_task_manager.py
@@ -23,7 +23,7 @@ from .results_poller import ResultsDispatcher
 # Set to True to enable extensive debug logging.
 # Useful for debugging concurrency issues.
 # Do not release with this setting set to True!
-ENABLE_DETAILED_DEBUG = False
+ENABLE_DETAILED_DEBUG = True
 
 
 class BackgroundTaskManager(QtCore.QObject):

--- a/python/task_manager/worker_thread.py
+++ b/python/task_manager/worker_thread.py
@@ -52,8 +52,8 @@ class WorkerThread(QtCore.QThread):
         """
         Shut down the thread and wait for it to exit before returning
         """
-        self._results_dispatcher = None
         with self._mutex:
+            self._results_dispatcher = None
             self._process_tasks = False
             self._wait_condition.notifyAll()
         self.wait()

--- a/tests/bg_task_manager/__init__.py
+++ b/tests/bg_task_manager/__init__.py
@@ -1,0 +1,6 @@
+# Copyright 2020 Autodesk, Inc.  All rights reserved.
+#
+# Use of this software is subject to the terms of the Autodesk license agreement
+# provided at the time of installation or download, or which otherwise accompanies
+# this software in either electronic or hard copy form.
+#

--- a/tests/bg_task_manager/__init__.py
+++ b/tests/bg_task_manager/__init__.py
@@ -1,6 +1,9 @@
-# Copyright 2020 Autodesk, Inc.  All rights reserved.
+# Copyright (c) 2020 Shotgun Software Inc.
 #
-# Use of this software is subject to the terms of the Autodesk license agreement
-# provided at the time of installation or download, or which otherwise accompanies
-# this software in either electronic or hard copy form.
+# CONFIDENTIAL AND PROPRIETARY
 #
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.

--- a/tests/bg_task_manager/test_background_task_manager.py
+++ b/tests/bg_task_manager/test_background_task_manager.py
@@ -1,9 +1,12 @@
-# Copyright 2020 Autodesk, Inc.  All rights reserved.
+# Copyright (c) 2020 Shotgun Software Inc.
 #
-# Use of this software is subject to the terms of the Autodesk license agreement
-# provided at the time of installation or download, or which otherwise accompanies
-# this software in either electronic or hard copy form.
+# CONFIDENTIAL AND PROPRIETARY
 #
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
 
 import sgtk
 

--- a/tests/bg_task_manager/test_background_task_manager.py
+++ b/tests/bg_task_manager/test_background_task_manager.py
@@ -44,7 +44,7 @@ class TestBackgroundTaskManager(TestShotgunUtilsFramework):
             task_ids.append(task_id)
 
         # Add a task that will shut down the background task manager.
-        # Note that since the manager will be shutdown by the manager, it means
+        # Note that since the manager will be shutdown by the callback, it means
         # no task completed callback will be invoked.
         self._manager.add_task(
             self._stop_background_task_manager, upstream_task_ids=task_ids
@@ -53,16 +53,14 @@ class TestBackgroundTaskManager(TestShotgunUtilsFramework):
         self._manager.start_processing()
         self._qapp.exec_()
 
-        # We're done here. All tasks should have completed.
-        # It only gets called 4 times even tough there are 5 tasks
-        # because stop background task manager clears everything.
+        # If we end up here, than all tasks should have popped themselves of
+        # the list in order and we should have an empty one.
         assert self._expected_priorities == []
 
     def _stop_background_task_manager(self):
         """
         Shuts down the background task manager
         """
-
         self._manager.shut_down()
         # Processes events until the dispatcher thread is done.
         while self._manager._results_dispatcher.isFinished() is False:
@@ -74,5 +72,5 @@ class TestBackgroundTaskManager(TestShotgunUtilsFramework):
         """
         Ensure the task that has just finished had the expected priority.
         """
-
-        assert priority_result == self._expected_priorities.pop()
+        assert priority_result == self._expected_priorities[-1]
+        self._expected_priorities.pop()

--- a/tests/bg_task_manager/test_background_task_manager.py
+++ b/tests/bg_task_manager/test_background_task_manager.py
@@ -1,0 +1,78 @@
+# Copyright 2020 Autodesk, Inc.  All rights reserved.
+#
+# Use of this software is subject to the terms of the Autodesk license agreement
+# provided at the time of installation or download, or which otherwise accompanies
+# this software in either electronic or hard copy form.
+#
+
+import sgtk
+
+from tank_test.tank_test_base import setUpModule  # noqa
+from base_test import TestShotgunUtilsFramework
+
+
+class TestBackgroundTaskManager(TestShotgunUtilsFramework):
+    """
+    Test the background task manager.
+    """
+
+    def setUp(self):
+        super(self.__class__, self).setUp()
+        self.BackgroundTaskManager = self.framework.import_module(
+            "task_manager"
+        ).BackgroundTaskManager
+
+    def test_priority_sorting(self):
+        """
+        Ensure priority is respected. Higher priority task get executed first.
+        """
+        # Use only one thread at a time so threads are launch in the order of the priority
+        # we're aiming for.
+        self._manager = self.BackgroundTaskManager(self._qapp, max_threads=1)
+        # Callback which will validate that tasks end in the right order.
+        self._manager.task_completed.connect(self._assert_priority_expected_cb)
+
+        # Spawn a few tasks with different priorities. None should be equivalent to 0.
+        self._expected_priorities = [-100, -1, None, 1, 2, 10]
+        task_ids = []
+        # Create the task out of order just to make sure that the background task manager
+        # is actually sorting them.
+        for priority in [None, 2, 10, 1, -1, -100]:
+            task_id = self._manager.add_task(
+                lambda prio=priority: prio, priority=priority
+            )
+            task_ids.append(task_id)
+
+        # Add a task that will shut down the background task manager.
+        # Note that since the manager will be shutdown by the manager, it means
+        # no task completed callback will be invoked.
+        self._manager.add_task(
+            self._stop_background_task_manager, upstream_task_ids=task_ids
+        )
+        # Start processing tasks and launch the main application loop.
+        self._manager.start_processing()
+        self._qapp.exec_()
+
+        # We're done here. All tasks should have completed.
+        # It only gets called 4 times even tough there are 5 tasks
+        # because stop background task manager clears everything.
+        assert self._expected_priorities == []
+
+    def _stop_background_task_manager(self):
+        """
+        Shuts down the background task manager
+        """
+
+        self._manager.shut_down()
+        # Processes events until the dispatcher thread is done.
+        while self._manager._results_dispatcher.isFinished() is False:
+            sgtk.platform.qt.QtGui.QApplication.processEvents()
+        # Now we can quit the app.
+        self._qapp.quit()
+
+    def _assert_priority_expected_cb(self, _, _2, priority_result):
+        """
+        Ensure the task that has just finished had the expected priority.
+        """
+
+        assert priority_result == self._expected_priorities.pop()

--- a/tests/python/base_test.py
+++ b/tests/python/base_test.py
@@ -10,7 +10,7 @@
 
 import os
 
-from tank_test.tank_test_base import *
+from tank_test.tank_test_base import TankTestBase
 import sgtk
 
 


### PR DESCRIPTION
The workfiles 2 app passes in a priotity for it's threads, unlike most of the rest of our code, so we didn't catch this until now.

In Python 2, comparing `int` and `NoneType` was possible, but it is not permitted in Python 3, so we're making sure that priorities are always numerical now.