### PR TITLE
Improve Python3 support

### DIFF
--- a/python/external_config/external_config_loader.py
+++ b/python/external_config/external_config_loader.py
@@ -166,7 +166,7 @@ class ExternalConfigurationLoader(QtCore.QObject):
         # in rapid succession.
         #
         # note: not using a generator since we are deleting in the loop
-        for task_id in self._task_ids.keys():
+        for task_id in list(self._task_ids.keys()):
             if self._task_ids[task_id] == project_id:
                 logger.debug(
                     "Discarding existing request_configurations request for project %s"

--- a/tests/external_config/test_external_config_loader.py
+++ b/tests/external_config/test_external_config_loader.py
@@ -104,3 +104,22 @@ class TestExternalConfigLoader(ExternalConfigBase):
         self.assertEqual(res_hash, "123")
         self.assertEqual(len(res_pcs), 1)
         self.assertEqual(res_pcs[0]["id"], self._pc["id"])
+
+    def test_request_configurations_twice(self):
+        """
+        Make sure requesting the same configuration twice only register it once.
+        """
+        ec = self.external_config_loader
+
+        ec.configurations_loaded = _MockedSignal()
+        ec.configurations_loaded.emit.assert_not_called()
+        self.bg_task_manager.add_task.reset_mock()
+
+        ec.request_configurations(self._project["id"])
+        self.assertEqual(len(ec._task_ids.items()), 1)
+        self.bg_task_manager.add_task.assert_called_once()
+        self.bg_task_manager.add_task.reset_mock()
+
+        ec.request_configurations(self._project["id"])
+        self.assertEqual(len(ec._task_ids.items()), 1)  # No duplicate of task ids
+        self.bg_task_manager.add_task.assert_called_once()


### PR DESCRIPTION
This pull request avoid this issue:

```
".../python/external_config/external_config_loader.py", line 169, in request_configurations
    for task_id in self._task_ids.keys():
RuntimeError: dictionary changed size during iteration
```

The fix is pretty straight forward. 