### PR TITLE
Unset PYTHONHOME in external_runner.py

### DIFF
--- a/python/external_config/scripts/external_runner.py
+++ b/python/external_config/scripts/external_runner.py
@@ -350,6 +350,12 @@ def main():
         else:
             os.environ["PYTHONPATH"] = arg_data["pythonpath"]
 
+    # The Python interpreter is now loaded and we don't want to pollute the
+    # processes spawned from this script and let the embedded interpreter set (or not!)
+    # his own home.
+    if "PYTHONHOME" in os.environ:
+        del os.environ["PYTHONHOME"]
+
     # Add application icon
     qt_application.setWindowIcon(qt_importer.QtGui.QIcon(arg_data["icon_path"]))
 


### PR DESCRIPTION
Some versions of Python sets the PYTHONHOME environment variable and it might conflict with some DCC since it affects the way Python is initialized. 

Ex. Maya and Nuke fail to start if the variable is set.

This change is required because upgrading the python interpreters in Shotgun Create introduces the behaviour of setting that variable. 