### PR TITLE
Serialize the user with the external runner args

### DIFF
--- a/python/external_config/config/config_base.py
+++ b/python/external_config/config/config_base.py
@@ -432,6 +432,9 @@ class ExternalConfiguration(QtCore.QObject):
                 icon_path=self._bundle.engine.icon_256,
                 pre_cache=pre_cache,
                 pythonpath=current_pypath,
+                user=sgtk.authentication.serialize_user(
+                    sgtk.get_authenticated_user(), use_json=True
+                ),
             )
         )
 

--- a/python/external_config/config/config_base.py
+++ b/python/external_config/config/config_base.py
@@ -417,6 +417,12 @@ class ExternalConfiguration(QtCore.QObject):
         # subprocesses.
         current_pypath = os.environ.get("PYTHONPATH")
 
+        serialized_user = None
+        if sgtk.get_authenticated_user():
+            serialized_user = sgtk.authentication.serialize_user(
+                sgtk.get_authenticated_user(), use_json=True
+            )
+
         args_file = create_parameter_file(
             dict(
                 action="cache_actions",
@@ -432,9 +438,7 @@ class ExternalConfiguration(QtCore.QObject):
                 icon_path=self._bundle.engine.icon_256,
                 pre_cache=pre_cache,
                 pythonpath=current_pypath,
-                user=sgtk.authentication.serialize_user(
-                    sgtk.get_authenticated_user(), use_json=True
-                ),
+                user=serialized_user,
             )
         )
 

--- a/python/external_config/external_command.py
+++ b/python/external_config/external_command.py
@@ -468,6 +468,12 @@ class ExternalCommand(object):
         # clean for any process that it might spawn, like when launching a DCC.
         current_pypath = os.environ.get("PYTHONPATH")
 
+        serialized_user = None
+        if sgtk.get_authenticated_user():
+            serialized_user = sgtk.authentication.serialize_user(
+                sgtk.get_authenticated_user(), use_json=True
+            )
+
         # pass arguments via a pickled temp file.
         args_file = create_parameter_file(
             dict(
@@ -485,9 +491,7 @@ class ExternalCommand(object):
                 supports_multiple_selection=self._sg_supports_multiple_selection,
                 pre_cache=pre_cache,
                 pythonpath=current_pypath,
-                user=sgtk.authentication.serialize_user(
-                    sgtk.get_authenticated_user(), use_json=True
-                ),
+                user=serialized_user,
             )
         )
         # compose the command we want to run

--- a/python/external_config/external_command.py
+++ b/python/external_config/external_command.py
@@ -485,6 +485,9 @@ class ExternalCommand(object):
                 supports_multiple_selection=self._sg_supports_multiple_selection,
                 pre_cache=pre_cache,
                 pythonpath=current_pypath,
+                user=sgtk.authentication.serialize_user(
+                    sgtk.get_authenticated_user(), use_json=True
+                ),
             )
         )
         # compose the command we want to run

--- a/python/external_config/scripts/external_runner.py
+++ b/python/external_config/scripts/external_runner.py
@@ -215,6 +215,7 @@ def _import_py_file(python_path, name):
 
 
 def start_engine(
+    user,
     configuration_uri,
     pipeline_config_id,
     plugin_id,
@@ -227,6 +228,7 @@ def start_engine(
     """
     Bootstraps into an engine.
 
+    :param ShotgunUser user: The user that have to be used while bootstraping the engine.
     :param str configuration_uri: URI to bootstrap (for when pipeline config id is unknown).
     :param int pipeline_config_id: Associated pipeline config id
     :param str plugin_id: Plugin id to use for bootstrap
@@ -245,7 +247,7 @@ def start_engine(
     logger.debug("Preparing ToolkitManager for command cache bootstrap.")
 
     # Setup the bootstrap manager.
-    manager = sgtk.bootstrap.ToolkitManager()
+    manager = sgtk.bootstrap.ToolkitManager(user)
     manager.plugin_id = plugin_id
     manager.bundle_cache_fallback_paths = bundle_cache_fallback_paths
 
@@ -354,11 +356,13 @@ def main():
     qt_application.setWindowIcon(qt_importer.QtGui.QIcon(arg_data["icon_path"]))
 
     action = arg_data["action"]
+    user = sgtk.authentication.deserialize_user(arg_data["user"])
     engine = None
 
     if action == "cache_actions":
         try:
             engine = start_engine(
+                user,
                 arg_data["configuration_uri"],
                 arg_data["pipeline_config_id"],
                 arg_data["plugin_id"],
@@ -403,6 +407,7 @@ def main():
 
     elif action == "execute_command":
         engine = start_engine(
+            user,
             arg_data["configuration_uri"],
             arg_data["pipeline_config_id"],
             arg_data["plugin_id"],

--- a/python/external_config/scripts/external_runner.py
+++ b/python/external_config/scripts/external_runner.py
@@ -359,6 +359,10 @@ def main():
     user = sgtk.authentication.deserialize_user(arg_data["user"])
     engine = None
 
+    user = None
+    if arg_data.get("user", None):
+        user = sgtk.authentication.deserialize_user(arg_data["user"])
+
     if action == "cache_actions":
         try:
             engine = start_engine(


### PR DESCRIPTION
Send the currently used user to the external runner so it doesn't rely
on having to grab the current user at runtime.

With this change, someone who trigger multiple actions and logout won't
get login screens appearing at the moment the action get executed.