### PR TITLE
SG-17970 user settings python 3 pickle issue fix

### DIFF
--- a/python/settings/user_settings.py
+++ b/python/settings/user_settings.py
@@ -148,7 +148,9 @@ class UserSettings(object):
             #
             # To get around this, we need to write a string inside the QSettings, so
             # use pickle.
-            value_str =six.ensure_str(cPickle.dumps(sanitize_qt(value), protocol=0), encoding="latin1")
+            value_str = six.ensure_str(
+                cPickle.dumps(sanitize_qt(value), protocol=0), encoding="latin1"
+            )
             self.__settings.setValue(full_name, value_str)
         except Exception as e:
             self.__fw.log_warning(

--- a/python/shotgun_model/util.py
+++ b/python/shotgun_model/util.py
@@ -69,7 +69,7 @@ def sanitize_for_qt_model(val):
     unicode errors. A safe strategy for storing unicode data inside
     Qt model roles is therefore to ensure everything is converted to
     unicode prior to insertion into the model. This method ensures
-    that. All string values will be coonverted to unicode. UTF-8
+    that. All string values will be converted to unicode. UTF-8
     is assumed for all strings:
 
     in:  {"a":"aaa", "b": 123, "c": {"x":"y", "z":"aa"}, "d": [ {"x":"y", "z":"aa"} ] }
@@ -108,8 +108,8 @@ def sanitize_qt(val):
     """
     Converts a value to a tk friendly and consistent representation.
     - QVariants are converted to native python structures
-    - QStrings are coverted to utf-8 encoded strs
-    - unicode objets are converted to utf-8 encoded strs
+    - QStrings are converted to utf-8 encoded strs
+    - unicode objects are converted to utf-8 encoded strs
 
     :param val: input object
     :returns: cleaned up data


### PR DESCRIPTION
We were seeing issues in Shotgun Desktop Python 3 with storing a datetime object as a setting.

```
2020-06-12 10:53:40,147 [ WARNING] Error storing user setting 'asite.shotgunstudio.com:project_recent_apps.215'. Error details: 'utf-8' codec can't decode byte 0xe4 in position 113: invalid continuation byte 
```

*Brief background: The settings utility tries to pickle objects into strings before passing them to QSettings to store, so that we have control over how that happens.* 

The problem was that it was using the `tk-core` pickle implementation which tries to ensure that the pickled object is a `utf-8` string. However for some reason, that I don't fully understand, it appears to need to be a `latin1` str. So rather than changing core we opted to handle the pickling inside the settings code.