### PR TITLE
SHOT-3508: Alternative PySide2 5.15.0 regression fix

### DIFF
--- a/python/task_manager/background_task_manager.py
+++ b/python/task_manager/background_task_manager.py
@@ -380,7 +380,7 @@ class BackgroundTaskManager(QtCore.QObject):
         # create a new worker thread - note, there are two different implementations of the WorkerThread class
         # that use two different recipes.  Although WorkerThreadB is arguably more correct it has some issues
         # in PyQt so WorkerThread is currently preferred - see the notes in the class above for further details
-        thread = WorkerThread(self._results_dispatcher, self)
+        thread = WorkerThread(self._results_dispatcher)
         if not isinstance(thread, WorkerThread):
             # for some reason (probably memory corruption somewhere else) I've occasionally seen the above
             # creation of a worker thread return another arbitrary object!  Added this in here so the code


### PR DESCRIPTION
Upgrading to PySide2 5.15 causes a deadlock when the WorkerThread's shut_down method is called.

In the past, we've had issues when mixing Qt and Python threading primitives and this is indeed what is going on here. The `WorkerThread` is a `QThread` but we use Python's `Mutex` and `Condition` classes to synchronize threads. I've simply modified the `WorkerThread` class to derive from Python's `Thread` class and now everything is fine.

I've had to modify the background manager test, as the last worker thread tried to shutdown the background manager. This meant that the worker ended up joining itself. Unfortunately, it appears Python threads can't join themselves, but Qt threads could, which means my change broke the test and introduced a side-effect.

Another subtle side-effect: the worker thread is not a QThread anymore, which means it can't be used to emit signals. We'll see in testing if this has an impact in our apps.