### PR TITLE
SG-20648 Fixes an issue with running the old style command.

### DIFF
--- a/python/external_config/scripts/external_runner.py
+++ b/python/external_config/scripts/external_runner.py
@@ -475,7 +475,7 @@ def main():
         # tk-shotgun apps are the only ones that supply a value for "supports_multiple_selection"
         # These apps' commands/callbacks are also the only ones that expect the extra parameters
         # entity_type and entity_ids to be passed in so we need to use a special method with them
-        if arg_data["supports_multiple_selection"] is not None:
+        if arg_data["supports_multiple_selection"] is True:
             engine.execute_old_style_command(
                 callback_name, arg_data["entity_type"], arg_data["entity_ids"]
             )


### PR DESCRIPTION
The old style command should only be used when the app is registered with supports multiple selection. 
Before this fix, it would run the old style command if the supports_multiple_selection was present but set to false.