### PR TITLE
SG-18781 - Set the cwd of the external_runner

### DIFF
--- a/python/external_config/external_command.py
+++ b/python/external_config/external_command.py
@@ -490,20 +490,23 @@ class ExternalCommand(object):
             sgtk.bootstrap.ToolkitManager.get_core_python_path(),
             args_file,
         ]
+        subprocess_cwd = sgtk.utils.sgtk.util.LocalFileStorageManager.get_global_root(
+            sgtk.utils.sgtk.util.LocalFileStorageManager.CACHE
+        )
+
         logger.debug("Command arguments: %s", args)
+        logger.debug("Command cwd: %s", subprocess_cwd)
 
         try:
             # Note: passing a copy of the environment in resolves some odd behavior with
             # the environment of processes spawned from the external_runner. This caused
             # some very bad behavior where it looked like PYTHONPATH was inherited from
             # this top-level environment rather than what is being set in external_runner
-            # prior to launch. Also, the pwd is set to the home directory of the current
-            # so we avoid a situation where the pwd contains conflicting DLLs, like
-            # SG Create's Qt DLLs that might be loaded before another software's Qt DLLs
-            # because of the way DLLs are loaded on Windows... (shorturl.at/nzDJW)
-            output = sgtk.util.process.subprocess_check_output(
-                args, cwd=os.path.expanduser("~")
-            )
+            # prior to launch. Also, the pwd is set a path we own so we avoid a situation
+            # where the pwd contains conflicting DLLs, like SG Create's Qt DLLs that might
+            # be loaded before another software's Qt DLLs because of the way DLLs are loaded...
+            # (shorturl.at/nzDJW)
+            output = sgtk.util.process.subprocess_check_output(args, cwd=subprocess_cwd)
             logger.debug("External execution complete. Output: %s" % output)
         except sgtk.util.process.SubprocessCalledProcessError as e:
             # caching failed!

--- a/python/external_config/external_command.py
+++ b/python/external_config/external_command.py
@@ -502,7 +502,7 @@ class ExternalCommand(object):
             # the environment of processes spawned from the external_runner. This caused
             # some very bad behavior where it looked like PYTHONPATH was inherited from
             # this top-level environment rather than what is being set in external_runner
-            # prior to launch. Also, the pwd is set a path we own so we avoid a situation
+            # prior to launch. Also, the cwd is set a path we own so we avoid a situation
             # where the pwd contains conflicting DLLs, like SG Create's Qt DLLs that might
             # be loaded before another software's Qt DLLs because of the way DLLs are loaded...
             # (shorturl.at/nzDJW)

--- a/python/external_config/external_command.py
+++ b/python/external_config/external_command.py
@@ -490,8 +490,8 @@ class ExternalCommand(object):
             sgtk.bootstrap.ToolkitManager.get_core_python_path(),
             args_file,
         ]
-        subprocess_cwd = sgtk.utils.sgtk.util.LocalFileStorageManager.get_global_root(
-            sgtk.utils.sgtk.util.LocalFileStorageManager.CACHE
+        subprocess_cwd = sgtk.util.LocalFileStorageManager.get_global_root(
+            sgtk.util.LocalFileStorageManager.CACHE
         )
 
         logger.debug("Command arguments: %s", args)

--- a/python/external_config/external_command.py
+++ b/python/external_config/external_command.py
@@ -502,7 +502,7 @@ class ExternalCommand(object):
             # SG Create's Qt DLLs that might be loaded before another software's Qt DLLs
             # because of the way DLLs are loaded on Windows... (shorturl.at/nzDJW)
             output = sgtk.util.process.subprocess_check_output(
-                args, pwd=os.path.expanduser("~")
+                args, cwd=os.path.expanduser("~")
             )
             logger.debug("External execution complete. Output: %s" % output)
         except sgtk.util.process.SubprocessCalledProcessError as e:

--- a/python/external_config/external_command.py
+++ b/python/external_config/external_command.py
@@ -497,8 +497,13 @@ class ExternalCommand(object):
             # the environment of processes spawned from the external_runner. This caused
             # some very bad behavior where it looked like PYTHONPATH was inherited from
             # this top-level environment rather than what is being set in external_runner
-            # prior to launch.
-            output = sgtk.util.process.subprocess_check_output(args)
+            # prior to launch. Also, the pwd is set to the home directory of the current
+            # so we avoid a situation where the pwd contains conflicting DLLs, like
+            # SG Create's Qt DLLs that might be loaded before another software's Qt DLLs
+            # because of the way DLLs are loaded on Windows... (shorturl.at/nzDJW)
+            output = sgtk.util.process.subprocess_check_output(
+                args, pwd=os.path.expanduser("~")
+            )
             logger.debug("External execution complete. Output: %s" % output)
         except sgtk.util.process.SubprocessCalledProcessError as e:
             # caching failed!


### PR DESCRIPTION
This pull request fixes an issue where starting some DCCs from Shotgun Create fails because of the way DLLs are handled on Windows. Before this change, Shotgun Create starts external_runner.py (and then any external command) from his PWD, which is his own bin folder. The situation might end up problematic because of the way DLLs are loaded on Windows. In certain cases, the app will look at DLLs in the current directory instead of where you would expect it to load things and things end up failing in a very unexpected way.

The solution here is to always set the PWD to the home directory of the user. Why the home directory? For no reason, it's an arbitrary path that always exists and where you are unlikely to have DLLs that might break your tools. I am open to switching this to any other directory that makes sense. The other candidate in my mind is the folder that contains the argument file, but I'm afraid of what's in people's temp folders.

Some literature: https://docs.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order#standard-search-order-for-desktop-applications