### PR TITLE
fix hang waiting for threads to close

### DIFF
--- a/python/task_manager/worker_thread.py
+++ b/python/task_manager/worker_thread.py
@@ -55,7 +55,9 @@ class WorkerThread(Thread):
             self._results_dispatcher = None
             self._process_tasks = False
             self._wait_condition.notifyAll()
-        self.join()
+            
+        self._process_tasks = False
+        #self.join()
 
     def run(self):
         """


### PR DESCRIPTION
Issue - (Nuke 13, tk-multi-workfiles2)

First launch of tk-multi-workfiles2 opens script fine. Attempting to run workfiles2 File Open again from that script opens script, but dialog hangs and crashes Nuke instance. Last log entry is "waiting for X threads to end..."

worker.join() is insufficient to close the threads, instead, set the local variable _process_tasks to False to end the custom run loop.