### PR TITLE
Removed inherited-members from all .rst files.

### DIFF
--- a/docs/external_config.rst
+++ b/docs/external_config.rst
@@ -29,19 +29,16 @@ Class ExternalConfigurationLoader
 ============================================
 .. autoclass:: ExternalConfigurationLoader
     :members:
-    :inherited-members:
 
 Class ExternalConfiguration
 ============================================
 
 .. autoclass:: ExternalConfiguration
     :members:
-    :inherited-members:
 
 Class ExternalCommand
 ============================================
 
 .. autoclass:: ExternalCommand
     :members:
-    :inherited-members:
     :exclude-members: create

--- a/docs/shotgun_data.rst
+++ b/docs/shotgun_data.rst
@@ -84,4 +84,3 @@ Class ShotgunDataRetriever
 
 .. autoclass:: ShotgunDataRetriever
     :members:
-    :inherited-members:

--- a/docs/shotgun_hierarchy_model.rst
+++ b/docs/shotgun_hierarchy_model.rst
@@ -148,7 +148,6 @@ specialized to hold the contents of a particular shotgun API
 refreshes its data asynchronously.
 
 .. autoclass:: ShotgunHierarchyModel
-    :inherited-members:
     :members:
     :exclude-members: canFetchMore,
                       fetchMore,

--- a/docs/shotgun_model.rst
+++ b/docs/shotgun_model.rst
@@ -190,7 +190,6 @@ types for the asset types. The leaf nodes in this case would be assets.
 
 .. autoclass:: ShotgunModel
     :members:
-    :inherited-members:
     :exclude-members: reset, clear, hasChildren, fetchMore, canFetchMore,
                       ensure_data_is_loaded, destroy, hard_refresh, is_data_cached
 

--- a/docs/task_manager.rst
+++ b/docs/task_manager.rst
@@ -95,4 +95,3 @@ Class BackgroundTaskManager
 
 .. autoclass:: BackgroundTaskManager
     :members:
-    :inherited-members:


### PR DESCRIPTION
I think it has to do with recent activity found here:
https://github.com/sphinx-doc/sphinx/search?o=desc&q=inherited-members&s=committer-date&type=commits
It seems like the SG docs _were_ looking fine because it was broken and now it works as expected so we need to remove this :inherited-members: definition.