### PR TITLE
SG-31932 Fix order when adding new items before caching

### DIFF
--- a/python/shotgun_model/shotgun_hierarchy_model.py
+++ b/python/shotgun_model/shotgun_hierarchy_model.py
@@ -518,12 +518,13 @@ class ShotgunHierarchyModel(ShotgunQueryModel):
         if icon:
             item.setIcon(icon)
 
-    def _create_item(self, parent, data_item):
+    def _create_item(self, parent, data_item, top_index=None):
         """
         Creates a model item for the tree given data out of the data store
 
         :param :class:`~PySide.QtGui.QStandardItem` parent: Model item to parent the node under
         :param :class:`ShotgunItemData` data_item: Data to populate new item with
+        :param int top_index: Indicates an index the item should be placed on the tree
 
         :returns: Model item
         :rtype: :class:`ShotgunStandardItem`

--- a/python/shotgun_model/shotgun_model.py
+++ b/python/shotgun_model/shotgun_model.py
@@ -605,12 +605,13 @@ class ShotgunModel(ShotgunQueryModel):
         row.extend(self._get_additional_columns(item, is_leaf, self.__column_fields))
         return row
 
-    def _create_item(self, parent, data_item):
+    def _create_item(self, parent, data_item, top_index=None):
         """
         Creates a model item for the tree given data out of the data store
 
         :param :class:`~PySide.QtGui.QStandardItem` parent: Model item to parent the node under
         :param :class:`ShotgunItemData` data_item: Data to populate new item with
+        :param int top_index: Indicates an index the item should be placed on the tree
 
         :returns: Model item
         :rtype: :class:`ShotgunStandardItem`
@@ -628,7 +629,10 @@ class ShotgunModel(ShotgunQueryModel):
         row = self._get_columns(item, data_item.is_leaf())
 
         # and attach the node
-        parent.appendRow(row)
+        if top_index is not None:
+            parent.insertRow(top_index, row)
+        else:
+            parent.appendRow(row)
 
         return item
 

--- a/python/shotgun_model/shotgun_query_model.py
+++ b/python/shotgun_model/shotgun_query_model.py
@@ -758,7 +758,6 @@ class ShotgunQueryModel(QtGui.QStandardItemModel):
         item = self._get_item_by_unique_id(uid)
 
         if not item:
-
             # item was not part of the model. Attempt to load its parents until it is visible.
             self._log_debug(
                 "Item %s does not exist in the tree - will expand tree." % data_item
@@ -1074,7 +1073,9 @@ class ShotgunQueryModel(QtGui.QStandardItemModel):
                                 )
                                 # Incoming items were added to the end.
                                 # We place them together at the top instead.
-                                self._create_item(parent_model_item, data_item, top_index=idx)
+                                self._create_item(
+                                    parent_model_item, data_item, top_index=idx
+                                )
                 elif item["mode"] == self._data_handler.DELETED:
                     # see if the node exists in the tree, in that case delete it.
                     # we check if it exists in the model because it may not have been

--- a/python/shotgun_model/shotgun_query_model.py
+++ b/python/shotgun_model/shotgun_query_model.py
@@ -409,12 +409,13 @@ class ShotgunQueryModel(QtGui.QStandardItemModel):
     # abstract, protected methods. these methods should be implemented by
     # subclasses to provide a consistent developer experience.
 
-    def _create_item(self, parent, data_item):
+    def _create_item(self, parent, data_item, top_index=None):
         """
         Creates a model item for the tree given data out of the data store
 
         :param :class:`~PySide.QtGui.QStandardItem` parent: Model item to parent the node under
         :param :class:`ShotgunItemData` data_item: Data to populate new item with
+        :param int top_index: Indicates an index the item should be placed on the tree
 
         :returns: Model item
         :rtype: :class:`ShotgunStandardItem`
@@ -1024,7 +1025,7 @@ class ShotgunQueryModel(QtGui.QStandardItemModel):
 
             # we have some items loaded into our qt model. Look at the diff
             # and make sure that what's loaded in the model is up to date.
-            for item in modified_items:
+            for idx, item in enumerate(modified_items):
                 data_item = item["data"]
 
                 self._log_debug("Processing change %s" % item)
@@ -1071,7 +1072,9 @@ class ShotgunQueryModel(QtGui.QStandardItemModel):
                                 self._log_debug(
                                     "Creating new model " "item for %s" % data_item
                                 )
-                                self._create_item(parent_model_item, data_item)
+                                # Incoming items were added to the end.
+                                # We place them together at the top instead.
+                                self._create_item(parent_model_item, data_item, top_index=idx)
                 elif item["mode"] == self._data_handler.DELETED:
                     # see if the node exists in the tree, in that case delete it.
                     # we check if it exists in the model because it may not have been


### PR DESCRIPTION
When [shotgunpanel](https://github.com/shotgunsoftware/tk-multi-shotgunpanel) finds new items (notes, publishes, etc) it appends them to the end of the UI list. However, the default ordering should be the newest first. This PR attempts to fix that by specifying the index where to create new items when SG data arrives.