### PR TITLE
SG-17742 Attempt to fix the crash issue with Houdini

### DIFF
--- a/python/shotgun_model/shotgun_query_model.py
+++ b/python/shotgun_model/shotgun_query_model.py
@@ -880,11 +880,15 @@ class ShotgunQueryModel(QtGui.QStandardItemModel):
 
         # delete the child leaves
         for index in range(node.rowCount(), 0, -1):
-            # Use `takeRow` instead of `removeRow` to prevent model from deleting
-            # the data before we're done using it. takeRow does not free the memory
-            # but we own the objects and do not keep a reference to it, so garbage
-            # collection will take care of freeing up the memory for us.
-            node.takeRow(index - 1)
+            if sgtk.platform.current_engine().instance_name == "tk-houdini":
+                node.removeRow(index - 1)
+            else:
+                # For every other engine,
+                # Use `takeRow` instead of `removeRow` to prevent model from deleting
+                # the data before we're done using it. takeRow does not free the memory
+                # but we own the objects and do not keep a reference to it, so garbage
+                # collection will take care of freeing up the memory for us.
+                node.takeRow(index - 1)
 
     def __remove_unique_id_r(self, item):
         """


### PR DESCRIPTION
When opening the tk-multi-shotgunpanel in Houdini, the Houdini app crashes on exit. This has been [reported by the community](https://community.shotgridsoftware.com/t/houdini-sgtk-app-crash-on-close/8827).

This PR attempts to fix this by properly destroying Qt objects on close.

- Check if the current engine is Houdini so it can invoke `removeRow` instead of `takeRow` when clearing child nodes.