### PR TITLE
SG-34509 SG-34514 Fix Sphinx issue with PySide6

### DIFF
--- a/docs/shotgun_hierarchy_model.rst
+++ b/docs/shotgun_hierarchy_model.rst
@@ -148,6 +148,7 @@ specialized to hold the contents of a particular shotgun API
 refreshes its data asynchronously.
 
 .. autoclass:: ShotgunHierarchyModel
+    :noindex:
     :inherited-members:
     :members:
     :exclude-members: canFetchMore,


### PR DESCRIPTION
Documentation output is very similar, but some inherit methods from `ShotgunHierarchyModel` are not populated due to cross-referencing issue with Sphinx.

Left image is our current published site. Right image is the preview.

![Screenshot 2024-02-08 at 09 36 48](https://github.com/shotgunsoftware/tk-framework-shotgunutils/assets/123113322/bff18d31-fd76-4653-8930-cb508c1a68dd)


Discovered by tk-toolchain CI for Python 3.11