### PR TITLE
SG-36129 add handling for data processing errors

### DIFF
--- a/python/shotgun_model/shotgun_model.py
+++ b/python/shotgun_model/shotgun_model.py
@@ -382,9 +382,13 @@ class ShotgunModel(ShotgunQueryModel):
 
         # construct the top level nodes
         self._log_debug("Creating model nodes for top level of data tree...")
-        nodes_generated = self._data_handler.generate_child_nodes(
-            None, root, self._create_item
-        )
+        try:
+            nodes_generated = self._data_handler.generate_child_nodes(
+                None, root, self._create_item
+            )
+        except Exception as e:
+            self._log_warning("Couldn't load cached data: %s" % e)
+            nodes_generated = 0
 
         # if we got some data, emit cache load signal
         if nodes_generated > 0:
@@ -658,6 +662,13 @@ class ShotgunModel(ShotgunQueryModel):
         # transfer a unique id from the data backend so we can
         # refer back to this node later on
         item.setData(data_item.unique_id, self._SG_ITEM_UNIQUE_ID)
+
+        if not data_item.field in data_item.shotgun_data:
+            raise sgtk.TankError(
+                "Field '%s' is not present in the data for entity type %s, "
+                "check the field exists in your Flow Production Tracking site."
+                % (data_item.field, data_item.shotgun_data["type"])
+            )
 
         # store the actual value we have
         item.setData(

--- a/python/shotgun_model/shotgun_query_model.py
+++ b/python/shotgun_model/shotgun_query_model.py
@@ -940,9 +940,17 @@ class ShotgunQueryModel(QtGui.QStandardItemModel):
         if self.__current_work_id == uid:
             # our data has arrived from sg!
             # process the data
-            self.__current_work_id = None
-            sg_data = data["sg"]
-            self.__on_sg_data_arrived(sg_data)
+            try:
+                self.__current_work_id = None
+                sg_data = data["sg"]
+                self.__on_sg_data_arrived(sg_data)
+            except Exception as e:
+                self._log_warning(
+                    "Error processing data from Flow Production Tracking: %s" % e
+                )
+                self.data_refresh_fail.emit(
+                    "Error processing data from Flow Production Tracking: %s" % e
+                )
 
         elif uid in self.__thumb_map:
             # a thumbnail is now present on disk!


### PR DESCRIPTION
This was added to aid a [feature on the tk-multi-shotgunpanel ](https://github.com/shotgunsoftware/tk-multi-shotgunpanel/pull/96)where if a bad custom sort field was added it would result in a error to the console but nothing in the UI.

This change means that the `data_refresh_fail` signal will be fired if the fetched data can't be processed.

I have concerns about the impact this change may have on other tools using this framework.