### PR TITLE
Update siblings' data on `ShotgunModel`.

### DIFF
--- a/python/shotgun_model/shotgun_model.py
+++ b/python/shotgun_model/shotgun_model.py
@@ -696,6 +696,23 @@ class ShotgunModel(ShotgunQueryModel):
 
         self._set_tooltip(item, data_item.shotgun_data)
 
+        # Update the text content for the siblings
+        row = item.index().row()
+        if row >= 0:
+            # We use range starting from 1 to skip the first column.
+            siblings = [
+                self.itemFromIndex(self.index(row, column))
+                for column in range(1, self.columnCount())
+            ]
+
+            for idx, column in enumerate(self.__column_fields):
+                column_text = sanitize_for_qt_model(data_item.shotgun_data.get(column))
+                sibling = siblings[idx] if idx < len(siblings) else None
+
+                if sibling and sibling != item and sibling.text() != column_text:
+                    self._log_debug(f"Updating sibling text content {sibling}")
+                    sibling.setText(column_text)
+
     ########################################################################################
     # private methods
 


### PR DESCRIPTION
When using `ShotgunModel._refresh_data()` to refresh the data model, only the first column seems to be refreshed, while the documentation says that a full rebuild of the model should be issued.

Reference [documentation](https://developers.shotgridsoftware.com/tk-framework-shotgunutils/shotgun_model.html#shotgun_model.ShotgunModel._refresh_data).

## Proposed fix

When new data arrives at the model, after a refresh is requested, the `_update_item` method was only updating the first item in the row. Now it discovers the rest of the items on the same row (siblings) and updates their text if needed.

## Reproduction steps

Let's say we create a simple dialog with a `QTableView` and a `ShotgunModel` that fetches my Assets added. Also, let's add a refresh button that connects to `model._refresh_data`.

<img width="633" alt="image" src="https://github.com/user-attachments/assets/7eb15c5f-8938-4390-8dc1-2dadb8a8c888" />

<details>

<summary>See the full code</summary>

> Let's remember that the first column will always be `Name` and it's harcoded to be the entity name

```py
import sgtk

from sgtk.platform.qt import QtGui

task_manager = sgtk.platform.import_framework(
    "tk-framework-shotgunutils", "task_manager"
)
shotgun_globals = sgtk.platform.import_framework(
    "tk-framework-shotgunutils", "shotgun_globals"
)
shotgun_model = sgtk.platform.import_framework(
    "tk-framework-shotgunutils", "shotgun_model"
)
ShotgunModel = shotgun_model.ShotgunModel

# standard toolkit logger
logger = sgtk.platform.get_logger(__name__)


def show_dialog(app_instance):
    app_instance.engine.show_dialog("Starter Template App...", app_instance, AppDialog)

class MyCustomModel(ShotgunModel):
    def __init__(self, parent, bg_task_manager):
        self.table_data = []
        ShotgunModel.__init__(
            self,
            parent,
            download_thumbs=True,
            bg_load_thumbs=True,
            bg_task_manager=bg_task_manager,
        )

    def load_data(self, project):
        self.columns = ["code", "sg_asset_type", "sg_status_list"]
        ShotgunModel._load_data(
            self,
            entity_type="Asset",
            filters=[["project", "is", project]],
            hierarchy=["code"],
            fields=self.columns,
            columns=self.columns,
        )
        self._refresh_data()
    

class AppDialog(QtGui.QWidget):
    def __init__(self):
        # first, call the base class and let it do its thing.
        QtGui.QWidget.__init__(self)

        # most of the useful accessors are available through the Application class instance
        # it is often handy to keep a reference to this. You can get it via the following method:
        self._app = sgtk.platform.current_bundle()

        self._task_manager = task_manager.BackgroundTaskManager(self)
        self._task_manager.start_processing()
        shotgun_globals.register_bg_task_manager(self._task_manager)

        # logging happens via a standard toolkit logger
        logger.info("Launching Starter Application...")

        self.reload_button = QtGui.QPushButton("Refresh")

        self.view = QtGui.QTableView(self)

        self.model = MyCustomModel(self, bg_task_manager=self._task_manager)
        self.view.setModel(self.model)

        self.main_layout = QtGui.QVBoxLayout()
        self.main_layout.addWidget(self.reload_button)
        self.main_layout.addWidget(self.view)

        self.setLayout(self.main_layout)

        self.reload_button.clicked.connect(self.model._refresh_data)
        
        self.model.load_data(project=self._app.context.project)
```
</details>

