### PR TITLE
SG-40414 UserSettings - Error details: 'str' object has no attribute 'decode'

### DIFF
--- a/python/settings/user_settings.py
+++ b/python/settings/user_settings.py
@@ -120,7 +120,7 @@ class UserSettings(object):
             if pickle_setting:
                 # Only sanitize and pickle the raw value if indicated.
                 sanitized_value = sanitize_qt(value)
-                settings_value = sgtk.util.pickle.dumps(sanitized_value).decode("utf-8")
+                settings_value = sgtk.util.pickle.dumps(sanitized_value)
             else:
                 # Store the raw value. Some objects cannot be retrieved correctly after
                 # sanitizing, like QByteArray.


### PR DESCRIPTION
### **Description** 

-  UserSettings - Error details: 'str' object has no attribute 'decode' 

Regression introduced in https://github.com/shotgunsoftware/tk-framework-shotgunutils/pull/168