### PR TITLE
SG-43665 Drop Python 3.7 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/psf/black
-    rev: 26.1.0
+    rev: 26.5.1
     hooks:
     - id: black
       language_version: python3

--- a/info.yml
+++ b/info.yml
@@ -23,6 +23,7 @@ description: "A Collection of Qt objects and utilities to simplify app developme
 # Required minimum versions for this item to run
 requires_shotgun_version:
 requires_core_version: "v0.19.18"
+minimum_python_version: "3.9"
 
 # the frameworks required to run this app
 frameworks:


### PR DESCRIPTION
Set `minimum_python_version` to `3.9` in `info.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)